### PR TITLE
Add a type for trailers

### DIFF
--- a/mit-commit-message-lints/src/lints/lib/duplicate_trailers.rs
+++ b/mit-commit-message-lints/src/lints/lib/duplicate_trailers.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashSet, iter::FromIterator};
 
 use crate::lints::lib::problem::Code;
-use crate::lints::lib::{CommitMessage, Problem};
+use crate::lints::lib::{CommitMessage, Problem, Trailer};
 
 pub(crate) const CONFIG_DUPLICATED_TRAILERS: &str = "duplicated-trailers";
 
@@ -16,16 +16,16 @@ fn has_duplicated_trailers(commit_message: &CommitMessage) -> Vec<String> {
         .collect::<Vec<String>>()
 }
 
-fn filter_without_duplicates(commit_message: &CommitMessage, trailer: &str) -> Option<String> {
-    Some(trailer)
+fn filter_without_duplicates(commit_message: &CommitMessage, trailer_key: &str) -> Option<String> {
+    Some(trailer_key)
         .map(String::from)
         .filter(|trailer| has_duplicated_trailer(commit_message, trailer))
 }
 
-fn has_duplicated_trailer(commit_message: &CommitMessage, trailer: &str) -> bool {
-    Some(commit_message.get_trailer(trailer))
-        .map(|trailers| (trailers.clone(), trailers.clone()))
-        .map(|(commit, unique)| (commit, HashSet::<&str>::from_iter(unique)))
+fn has_duplicated_trailer(commit_message: &CommitMessage, trailer_key: &str) -> bool {
+    Some(commit_message.get_trailer(trailer_key))
+        .map(|trailers| (trailers.clone(), trailers))
+        .map(|(commit, unique)| (commit, HashSet::<Trailer>::from_iter(unique)))
         .map(|(commit, unique)| commit.len() != unique.len())
         .unwrap()
 }

--- a/mit-commit-message-lints/src/lints/lib/error.rs
+++ b/mit-commit-message-lints/src/lints/lib/error.rs
@@ -1,0 +1,4 @@
+#[derive(Debug, PartialEq)]
+pub enum Error {
+    FailedToParseTrailer { string: String },
+}

--- a/mit-commit-message-lints/src/lints/lib/mod.rs
+++ b/mit-commit-message-lints/src/lints/lib/mod.rs
@@ -1,11 +1,15 @@
 mod commit_message;
+mod error;
 mod lint;
 mod lints;
+mod trailer;
 
 pub use commit_message::CommitMessage;
+pub use error::Error;
 pub use lint::Lint;
 pub use lints::Lints;
 pub use problem::{Code, Problem};
+pub use trailer::Trailer;
 
 mod duplicate_trailers;
 mod missing_jira_issue_key;

--- a/mit-commit-message-lints/src/lints/lib/trailer.rs
+++ b/mit-commit-message-lints/src/lints/lib/trailer.rs
@@ -1,0 +1,98 @@
+use std::fmt;
+use std::str::FromStr;
+
+use super::Error;
+
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub struct Trailer {
+    key: String,
+    value: String,
+}
+
+impl Trailer {
+    #[must_use]
+    pub fn new(key: &str, value: &str) -> Self {
+        Self {
+            key: key.into(),
+            value: value.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn has_key(&self, key: &str) -> bool {
+        key == self.key
+    }
+}
+
+impl FromStr for Trailer {
+    type Err = Error;
+
+    fn from_str(string: &str) -> Result<Self, Self::Err> {
+        if string.contains(':') {
+            let parts: Vec<&str> = string.splitn(2, ':').collect();
+            Ok(Trailer {
+                key: parts[0].trim().into(),
+                value: parts[1].trim().into(),
+            })
+        } else {
+            Err(Error::FailedToParseTrailer {
+                string: string.into(),
+            })
+        }
+    }
+}
+
+impl fmt::Display for Trailer {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}: {}", self.key, self.value)
+    }
+}
+
+#[cfg(test)]
+mod test_trailer {
+    use super::{Error, FromStr, Trailer};
+
+    #[test]
+    fn from_str_with_bad_trailer() {
+        assert_eq!(
+            Err(Error::FailedToParseTrailer {
+                string: "no colon here".into(),
+            }),
+            Trailer::from_str("no colon here")
+        )
+    }
+
+    #[test]
+    fn from_str_with_good_trailer() {
+        assert_eq!(
+            Ok(Trailer::new("Key", "Value")),
+            Trailer::from_str("Key:Value")
+        )
+    }
+
+    #[test]
+    fn from_str_with_good_trailer_with_whitespace() {
+        assert_eq!(
+            Ok(Trailer::new("Key Part", "Value Part")),
+            Trailer::from_str(" Key Part : Value Part ")
+        )
+    }
+
+    #[test]
+    fn to_str_returns_formatted_trailer() {
+        assert_eq!(
+            "Trailer: Value",
+            Trailer::new("Trailer", "Value").to_string()
+        )
+    }
+
+    #[test]
+    fn has_key_returns_false_if_key_does_not_match() {
+        assert_eq!(false, Trailer::new("key", "value").has_key("not-key"))
+    }
+
+    #[test]
+    fn has_key_returns_true_if_key_does_match() {
+        assert_eq!(true, Trailer::new("key", "value").has_key("key"))
+    }
+}

--- a/mit-prepare-commit-msg/src/main.rs
+++ b/mit-prepare-commit-msg/src/main.rs
@@ -6,7 +6,7 @@ use crate::MitPrepareCommitMessageError::MissingCommitFilePath;
 use mit_commit_message_lints::{
     author::{entities::Author, vcs::get_coauthor_configuration},
     external::vcs::Git2,
-    lints::lib::CommitMessage,
+    lints::lib::{CommitMessage, Trailer},
 };
 use std::convert::TryFrom;
 use std::path::PathBuf;
@@ -43,7 +43,7 @@ fn append_coauthors_to_commit_message(
         "{}",
         authors
             .iter()
-            .map(|x| format!("Co-authored-by: {} <{}>", x.name(), x.email()))
+            .map(|x| Trailer::new("Co-authored-by", &format!("{} <{}>", x.name(), x.email())))
             .fold(commit_message, |message, trailer| message
                 .add_trailer(&trailer))
     );

--- a/pb-commit-message-lints/src/lints/lib/mod.rs
+++ b/pb-commit-message-lints/src/lints/lib/mod.rs
@@ -1,0 +1,7 @@
+mod commit_message;
+mod error;
+mod trailer;
+
+pub use commit_message::CommitMessage;
+pub use error::Error;
+pub use trailer::Trailer;

--- a/pb-prepare-commit-msg/src/main.rs
+++ b/pb-prepare-commit-msg/src/main.rs
@@ -1,0 +1,131 @@
+use std::{env, fs::File, io::Write, process};
+
+use clap::{crate_authors, crate_version, App, Arg};
+
+use pb_commit_message_lints::{
+    author::{entities::Author, vcs::get_coauthor_configuration},
+    errors::PbCommitMessageLintsError,
+    external::vcs::Git2,
+    lints::lib::{CommitMessage, Trailer},
+};
+use std::{
+    convert::TryFrom,
+    error::Error,
+    fmt::{Display, Formatter},
+    path::PathBuf,
+};
+
+fn display_err_and_exit<T>(error: &PbPrepareCommitMessageError) -> T {
+    eprintln!("{}", error);
+    process::exit(1);
+}
+
+fn main() {
+    let matches = app().get_matches();
+
+    let commit_message_path = matches
+        .value_of("commit-message-path")
+        .map(PathBuf::from)
+        .expect("Expected commit file path");
+    let current_dir = env::current_dir()
+        .map_err(|err| PbPrepareCommitMessageError::new_io("$PWD".into(), &err))
+        .unwrap_or_else(|err| display_err_and_exit(&err));
+
+    let mut git_config = Git2::try_from(current_dir)
+        .map_err(PbPrepareCommitMessageError::from)
+        .unwrap_or_else(|err| display_err_and_exit(&err));
+
+    if let Some(authors) = get_coauthor_configuration(&mut git_config)
+        .map_err(PbPrepareCommitMessageError::from)
+        .unwrap_or_else(|err| display_err_and_exit(&err))
+    {
+        append_coauthors_to_commit_message(commit_message_path, &authors)
+            .map_err(PbPrepareCommitMessageError::from)
+            .unwrap_or_else(|err| display_err_and_exit(&err))
+    }
+}
+
+fn app() -> App<'static, 'static> {
+    App::new(env!("CARGO_PKG_NAME"))
+        .version(crate_version!())
+        .author(crate_authors!())
+        .about(env!("CARGO_PKG_DESCRIPTION"))
+        .arg(
+            Arg::with_name("commit-message-path")
+                .help("The name of the file that contains the commit log message")
+                .index(1)
+                .required(true),
+        )
+        .arg(
+            Arg::with_name("commit-message-source")
+                .help(
+                    "The commit message, and can be: message (if a -m or -F option was given to \
+                     git); template (if a -t option was given or the configuration option \
+                     commit.template is set in git); merge (if the commit is a merge or a \
+                     .git/MERGE_MSG file exists); squash (if a .git/SQUASH_MSG file exists); or \
+                     commit",
+                )
+                .index(2)
+                .required(false),
+        )
+        .arg(
+            Arg::with_name("commit-sha")
+                .help("Commit SHA-1 (if a -c, -C or --amend option was given to git).")
+                .index(3)
+                .required(false),
+        )
+}
+
+fn append_coauthors_to_commit_message(
+    commit_message_path: PathBuf,
+    authors: &[Author],
+) -> Result<(), PbPrepareCommitMessageError> {
+    let path = String::from(commit_message_path.to_string_lossy());
+    let commit_message = CommitMessage::try_from(commit_message_path.clone())?;
+
+    let message = format!(
+        "{}",
+        authors
+            .iter()
+            .map(|x| Trailer::new("Co-authored-by", &format!("{} <{}>", x.name(), x.email())))
+            .fold(commit_message, |message, trailer| message
+                .add_trailer(&trailer))
+    );
+
+    File::create(commit_message_path)
+        .and_then(|mut file| file.write_all(message.as_bytes()))
+        .map_err(|err| PbPrepareCommitMessageError::new_io(path, &err))
+}
+
+#[derive(Debug)]
+enum PbPrepareCommitMessageError {
+    PbCommitMessageLintsError(PbCommitMessageLintsError),
+    Io(String, String),
+}
+
+impl Display for PbPrepareCommitMessageError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PbPrepareCommitMessageError::PbCommitMessageLintsError(error) => write!(f, "{}", error),
+            PbPrepareCommitMessageError::Io(file_source, error) => write!(
+                f,
+                "Failed to read author config from `{}`:\n{}",
+                file_source, error
+            ),
+        }
+    }
+}
+
+impl From<PbCommitMessageLintsError> for PbPrepareCommitMessageError {
+    fn from(from: PbCommitMessageLintsError) -> Self {
+        PbPrepareCommitMessageError::PbCommitMessageLintsError(from)
+    }
+}
+
+impl Error for PbPrepareCommitMessageError {}
+
+impl PbPrepareCommitMessageError {
+    fn new_io(source: String, error: &std::io::Error) -> PbPrepareCommitMessageError {
+        PbPrepareCommitMessageError::Io(source, format!("{}", error))
+    }
+}


### PR DESCRIPTION
A refactor to add a type for git commit message trailers. Since these have a specific format and are passed around, capturing this information in the type system improves clarity and reduces risk of introducing bugs.