### PR TITLE
Try merging commits

### DIFF
--- a/.github/workflows/update-tap.yml
+++ b/.github/workflows/update-tap.yml
@@ -145,6 +145,8 @@ jobs:
         run: |
           cd "$(brew --repo)/Library/Taps/purplebooth/homebrew-repo"
           git checkout -b "$REPOSITORY_NAME-$(echo $GIT_TAG | sed 's/^refs\/tags\///')-bottle"
+          git reset --soft HEAD~1
+          git commit --amend -C HEAD
           git fetch && git rebase origin/main
           git push -f origin "$REPOSITORY_NAME-$(echo $GIT_TAG | sed 's/^refs\/tags\///')"
           brew install github/gh/gh


### PR DESCRIPTION
This tries merging the commits before pushing, the idea is that when we
rebase we get the correct collisions against bottles that we don't get
when we're doing the normal bottle prs
