### PR TITLE
Added subject and body lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ me to learn Rust. It's a bit more than that now, with lints for issues.
 
   - **duplicated-trailers** - Detect duplicated `Signed-off-by` and
     `Co-authored-by` Trailers. *Default: `enabled`*
+  - **subject-not-separated-from-body** - If there is a body, enforce a gap between it and the subject. *Default: `enabled`*
   - **pivotal-tracker-id-missing** - Detect missing Pivotal Tracker Id
     *Default: `disabled`*
   - **jira-issue-key-missing** - Detect missing Jira Issue Key *Default:

--- a/mit-commit-message-lints/src/lints/lib/duplicate_trailers.rs
+++ b/mit-commit-message-lints/src/lints/lib/duplicate_trailers.rs
@@ -3,7 +3,7 @@ use std::{collections::HashSet, iter::FromIterator};
 use crate::lints::lib::problem::Code;
 use crate::lints::lib::{CommitMessage, Problem, Trailer};
 
-pub(crate) const CONFIG_DUPLICATED_TRAILERS: &str = "duplicated-trailers";
+pub(crate) const CONFIG: &str = "duplicated-trailers";
 
 const TRAILERS_TO_CHECK_FOR_DUPLICATES: [&str; 2] = ["Signed-off-by", "Co-authored-by"];
 const FIELD_SINGULAR: &str = "field";
@@ -30,7 +30,7 @@ fn has_duplicated_trailer(commit_message: &CommitMessage, trailer_key: &str) -> 
         .unwrap()
 }
 
-pub(crate) fn lint_duplicated_trailers(commit_message: &CommitMessage) -> Option<Problem> {
+pub(crate) fn lint(commit_message: &CommitMessage) -> Option<Problem> {
     let duplicated_trailers = has_duplicated_trailers(commit_message);
     if duplicated_trailers.is_empty() {
         None
@@ -150,7 +150,7 @@ mod tests_has_duplicated_trailers {
     }
 
     fn test_lint_duplicated_trailers(message: String, expected: &Option<Problem>) {
-        let actual = &lint_duplicated_trailers(&CommitMessage::new(message));
+        let actual = &lint(&CommitMessage::new(message));
         assert_eq!(
             actual, expected,
             "Expected {:?}, found {:?}",

--- a/mit-commit-message-lints/src/lints/lib/lint.rs
+++ b/mit-commit-message-lints/src/lints/lib/lint.rs
@@ -1,13 +1,6 @@
-use crate::lints::lib::duplicate_trailers::lint_duplicated_trailers;
-
-use crate::lints::lib::missing_github_id::lint_missing_github_id;
-use crate::lints::lib::missing_jira_issue_key::lint_missing_jira_issue_key;
-use crate::lints::lib::missing_pivotal_tracker_id::lint_missing_pivotal_tracker_id;
+use crate::lints::lib;
 use crate::lints::lib::problem::Problem;
-use crate::lints::lib::{
-    duplicate_trailers, missing_github_id, missing_jira_issue_key, missing_pivotal_tracker_id,
-    CommitMessage, Lints,
-};
+use crate::lints::lib::{CommitMessage, Lints};
 use std::convert::TryInto;
 use thiserror::Error;
 
@@ -18,6 +11,7 @@ pub enum Lint {
     PivotalTrackerIdMissing,
     JiraIssueKeyMissing,
     GitHubIdMissing,
+    SubjectNotSeparateFromBody,
 }
 
 pub(crate) const CONFIG_KEY_PREFIX: &str = "mit.lint";
@@ -52,22 +46,22 @@ impl Lint {
     #[must_use]
     pub fn name(self) -> &'static str {
         match self {
-            Lint::DuplicatedTrailers => duplicate_trailers::CONFIG_DUPLICATED_TRAILERS,
-            Lint::PivotalTrackerIdMissing => {
-                missing_pivotal_tracker_id::CONFIG_PIVOTAL_TRACKER_ID_MISSING
-            }
-            Lint::JiraIssueKeyMissing => missing_jira_issue_key::CONFIG_JIRA_ISSUE_KEY_MISSING,
-            Lint::GitHubIdMissing => missing_github_id::CONFIG_GITHUB_ID_MISSING,
+            Lint::DuplicatedTrailers => lib::duplicate_trailers::CONFIG,
+            Lint::PivotalTrackerIdMissing => lib::missing_pivotal_tracker_id::CONFIG,
+            Lint::JiraIssueKeyMissing => lib::missing_jira_issue_key::CONFIG,
+            Lint::GitHubIdMissing => lib::missing_github_id::CONFIG,
+            Lint::SubjectNotSeparateFromBody => lib::subject_not_seperate_from_body::CONFIG,
         }
     }
 }
 
 impl Lint {
     pub fn iterator() -> impl Iterator<Item = Lint> {
-        static LINTS: [Lint; 3] = [
+        static LINTS: [Lint; 4] = [
             Lint::DuplicatedTrailers,
             Lint::PivotalTrackerIdMissing,
             Lint::JiraIssueKeyMissing,
+            Lint::SubjectNotSeparateFromBody,
         ];
         LINTS.iter().copied()
     }
@@ -80,10 +74,13 @@ impl Lint {
     #[must_use]
     pub fn lint(self, commit_message: &CommitMessage) -> Option<Problem> {
         match self {
-            Lint::DuplicatedTrailers => lint_duplicated_trailers(commit_message),
-            Lint::PivotalTrackerIdMissing => lint_missing_pivotal_tracker_id(commit_message),
-            Lint::JiraIssueKeyMissing => lint_missing_jira_issue_key(commit_message),
-            Lint::GitHubIdMissing => lint_missing_github_id(commit_message),
+            Lint::DuplicatedTrailers => lib::duplicate_trailers::lint(commit_message),
+            Lint::PivotalTrackerIdMissing => lib::missing_pivotal_tracker_id::lint(commit_message),
+            Lint::JiraIssueKeyMissing => lib::missing_jira_issue_key::lint(commit_message),
+            Lint::GitHubIdMissing => lib::missing_github_id::lint(commit_message),
+            Lint::SubjectNotSeparateFromBody => {
+                lib::subject_not_seperate_from_body::lint(commit_message)
+            }
         }
     }
 

--- a/mit-commit-message-lints/src/lints/lib/lints.rs
+++ b/mit-commit-message-lints/src/lints/lib/lints.rs
@@ -79,6 +79,7 @@ impl Lints {
                 get_config_or_default(config, Lint::PivotalTrackerIdMissing, false)?,
                 get_config_or_default(config, Lint::JiraIssueKeyMissing, false)?,
                 get_config_or_default(config, Lint::GitHubIdMissing, false)?,
+                get_config_or_default(config, Lint::SubjectNotSeparateFromBody, true)?,
             ]
             .into_iter()
             .flatten()
@@ -152,7 +153,7 @@ mod tests {
 
     use crate::{external::InMemory, lints::Lint::DuplicatedTrailers};
 
-    use crate::lints::lib::lint::Lint::GitHubIdMissing;
+    use crate::lints::lib::lint::Lint::{GitHubIdMissing, SubjectNotSeparateFromBody};
     use std::convert::TryInto;
 
     #[test]
@@ -238,6 +239,7 @@ mod tests {
 
         let mut lints = BTreeSet::new();
         lints.insert(DuplicatedTrailers);
+        lints.insert(SubjectNotSeparateFromBody);
 
         let expected = Lints::new(lints);
 
@@ -267,6 +269,7 @@ mod tests {
         let mut lints = BTreeSet::new();
         lints.insert(DuplicatedTrailers);
         lints.insert(PivotalTrackerIdMissing);
+        lints.insert(SubjectNotSeparateFromBody);
         let expected = Lints::new(lints);
 
         assert_eq!(
@@ -292,7 +295,8 @@ mod tests {
         )
         .expect("Failed to parse toml");
 
-        let lints = BTreeSet::new();
+        let mut lints = BTreeSet::new();
+        lints.insert(SubjectNotSeparateFromBody);
         let expected = Lints::new(lints);
 
         assert_eq!(
@@ -309,6 +313,7 @@ mod tests {
 
         let mut lints = BTreeSet::new();
         lints.insert(DuplicatedTrailers);
+        lints.insert(SubjectNotSeparateFromBody);
         let expected = Lints::new(lints);
 
         let actual = Lints::try_from_vcs(&mut config).expect("Failed to read lints from VCS");
@@ -327,7 +332,9 @@ mod tests {
         let mut config = InMemory::new(&mut strings);
 
         let actual = Lints::try_from_vcs(&mut config).expect("Failed to read lints from VCS");
-        let expected: Lints = Lints::new(BTreeSet::new());
+        let mut lints = BTreeSet::new();
+        lints.insert(SubjectNotSeparateFromBody);
+        let expected: Lints = Lints::new(lints);
 
         assert_eq!(
             expected, actual,
@@ -344,6 +351,7 @@ mod tests {
 
         let mut lints = BTreeSet::new();
         lints.insert(DuplicatedTrailers);
+        lints.insert(SubjectNotSeparateFromBody);
         let expected = Lints::new(lints);
 
         let actual = Lints::try_from_vcs(&mut config).expect("Failed to read lints from VCS");
@@ -364,6 +372,7 @@ mod tests {
         let mut lints = BTreeSet::new();
         lints.insert(DuplicatedTrailers);
         lints.insert(PivotalTrackerIdMissing);
+        lints.insert(SubjectNotSeparateFromBody);
         let expected = Lints::new(lints);
 
         let actual = Lints::try_from_vcs(&mut config).expect("Failed to read lints from VCS");
@@ -384,6 +393,7 @@ mod tests {
         let mut lints = BTreeSet::new();
         lints.insert(DuplicatedTrailers);
         lints.insert(GitHubIdMissing);
+        lints.insert(SubjectNotSeparateFromBody);
         let expected = Lints::new(lints);
 
         let actual = Lints::try_from_vcs(&mut config).expect("Failed to read lints from VCS");
@@ -404,6 +414,7 @@ mod tests {
         let mut lints = BTreeSet::new();
         lints.insert(DuplicatedTrailers);
         lints.insert(JiraIssueKeyMissing);
+        lints.insert(SubjectNotSeparateFromBody);
         let expected = Lints::new(lints);
 
         let actual = Lints::try_from_vcs(&mut config).expect("Failed to read lints from VCS");
@@ -425,6 +436,7 @@ mod tests {
 
         let mut lints = BTreeSet::new();
         lints.insert(DuplicatedTrailers);
+        lints.insert(SubjectNotSeparateFromBody);
         let expected = Lints::new(lints);
 
         assert_eq!(

--- a/mit-commit-message-lints/src/lints/lib/missing_github_id.rs
+++ b/mit-commit-message-lints/src/lints/lib/missing_github_id.rs
@@ -4,7 +4,7 @@ use crate::lints::lib::problem::Code;
 use crate::lints::lib::{CommitMessage, Problem};
 use indoc::indoc;
 
-pub(crate) const CONFIG_GITHUB_ID_MISSING: &str = "github-id-missing";
+pub(crate) const CONFIG: &str = "github-id-missing";
 
 const GITHUB_HELP_MESSAGE: &str = indoc!(
     "
@@ -41,7 +41,7 @@ fn has_missing_github_id(commit_message: &CommitMessage) -> bool {
     !commit_message.matches_pattern(&re)
 }
 
-pub(crate) fn lint_missing_github_id(commit_message: &CommitMessage) -> Option<Problem> {
+pub(crate) fn lint(commit_message: &CommitMessage) -> Option<Problem> {
     if has_missing_github_id(commit_message) {
         Some(Problem::new(
             GITHUB_HELP_MESSAGE.into(),
@@ -394,7 +394,7 @@ mod tests_has_missing_github_id {
     }
 
     fn test_has_missing_github_id(message: &str, expected: &Option<Problem>) {
-        let actual = &lint_missing_github_id(&CommitMessage::new(message.into()));
+        let actual = &lint(&CommitMessage::new(message.into()));
         assert_eq!(
             actual, expected,
             "Message {:?} should have returned {:?}, found {:?}",

--- a/mit-commit-message-lints/src/lints/lib/missing_jira_issue_key.rs
+++ b/mit-commit-message-lints/src/lints/lib/missing_jira_issue_key.rs
@@ -4,7 +4,7 @@ use crate::lints::lib::problem::Code;
 use crate::lints::lib::{CommitMessage, Problem};
 use indoc::indoc;
 
-pub(crate) const CONFIG_JIRA_ISSUE_KEY_MISSING: &str = "jira-issue-key-missing";
+pub(crate) const CONFIG: &str = "jira-issue-key-missing";
 
 const JIRA_HELP_MESSAGE: &str = indoc!(
     "
@@ -21,7 +21,7 @@ fn has_missing_jira_issue_key(commit_message: &CommitMessage) -> bool {
     !commit_message.matches_pattern(&re)
 }
 
-pub(crate) fn lint_missing_jira_issue_key(commit_message: &CommitMessage) -> Option<Problem> {
+pub(crate) fn lint(commit_message: &CommitMessage) -> Option<Problem> {
     if has_missing_jira_issue_key(commit_message) {
         Some(Problem::new(
             JIRA_HELP_MESSAGE.into(),
@@ -170,7 +170,7 @@ mod tests_has_missing_jira_issue_key {
     }
 
     fn test_has_missing_jira_issue_key(message: &str, expected: &Option<Problem>) {
-        let actual = &lint_missing_jira_issue_key(&CommitMessage::new(message.into()));
+        let actual = &lint(&CommitMessage::new(message.into()));
         assert_eq!(
             actual, expected,
             "Message {:?} should have returned {:?}, found {:?}",

--- a/mit-commit-message-lints/src/lints/lib/missing_pivotal_tracker_id.rs
+++ b/mit-commit-message-lints/src/lints/lib/missing_pivotal_tracker_id.rs
@@ -4,7 +4,7 @@ use crate::lints::lib::problem::Code;
 use crate::lints::lib::{CommitMessage, Problem};
 use indoc::indoc;
 
-pub(crate) const CONFIG_PIVOTAL_TRACKER_ID_MISSING: &str = "pivotal-tracker-id-missing";
+pub(crate) const CONFIG: &str = "pivotal-tracker-id-missing";
 
 const REGEX_PIVOTAL_TRACKER_ID: &str =
     r"(?i)\[(((finish|fix)(ed|es)?|complete[ds]?|deliver(s|ed)?) )?#\d+([, ]#\d+)*]";
@@ -18,7 +18,7 @@ fn has_no_pivotal_tracker_id(text: &CommitMessage) -> bool {
     !text.matches_pattern(&re)
 }
 
-pub(crate) fn lint_missing_pivotal_tracker_id(commit_message: &CommitMessage) -> Option<Problem> {
+pub(crate) fn lint(commit_message: &CommitMessage) -> Option<Problem> {
     if has_missing_pivotal_tracker_id(commit_message) {
         Some(Problem::new(
             PIVOTAL_TRACKER_HELP.into(),
@@ -72,7 +72,7 @@ mod tests_has_missing_pivotal_tracker_id {
     }
 
     fn test_has_missing_pivotal_tracker_id(message: &str, expected: &Option<Problem>) {
-        let actual = &lint_missing_pivotal_tracker_id(&CommitMessage::new(message.into()));
+        let actual = &lint(&CommitMessage::new(message.into()));
         assert_eq!(
             actual, expected,
             "Message {:?} should have returned {:?}, found {:?}",

--- a/mit-commit-message-lints/src/lints/lib/mod.rs
+++ b/mit-commit-message-lints/src/lints/lib/mod.rs
@@ -2,6 +2,7 @@ mod commit_message;
 mod error;
 mod lint;
 mod lints;
+mod subject_not_seperate_from_body;
 mod trailer;
 
 pub use commit_message::CommitMessage;

--- a/mit-commit-message-lints/src/lints/lib/problem.rs
+++ b/mit-commit-message-lints/src/lints/lib/problem.rs
@@ -31,4 +31,5 @@ pub enum Code {
     PivotalTrackerIdMissing,
     JiraIssueKeyMissing,
     GitHubIdMissing,
+    SubjectNotSeparateFromBody,
 }

--- a/mit-commit-message-lints/src/lints/lib/subject_not_seperate_from_body.rs
+++ b/mit-commit-message-lints/src/lints/lib/subject_not_seperate_from_body.rs
@@ -1,0 +1,157 @@
+use crate::lints::lib::problem::Code;
+use crate::lints::lib::{CommitMessage, Problem};
+use indoc::indoc;
+
+pub(crate) const CONFIG: &str = "subject-not-separated-from-body";
+
+const HELP_MESSAGE: &str = indoc!(
+    "
+    Your commit is not well formed
+
+    To fix this separate subject from body with a blank line
+
+    For example:
+
+    Aligns time sprondle
+
+    The time sprondle is drifting backwards in the current
+    configuration, this corrects that.
+    "
+);
+
+const SIZE_OF_SUBJECT: usize = 1;
+
+fn has_subject_not_separate_from_body(commit_message: &CommitMessage) -> bool {
+    let line_count = commit_message.content_line_count();
+
+    match line_count {
+        1 => false,
+        2 => true,
+        _ => commit_message.get_body().lines().count() + SIZE_OF_SUBJECT == line_count,
+    }
+}
+
+pub(crate) fn lint(commit_message: &CommitMessage) -> Option<Problem> {
+    if has_subject_not_separate_from_body(commit_message) {
+        Some(Problem::new(
+            HELP_MESSAGE.into(),
+            Code::SubjectNotSeparateFromBody,
+        ))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::wildcard_imports)]
+
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn with_gutter() {
+        test_subject_not_seperate_from_body(
+            indoc!(
+                "
+                An example commit
+
+                This is an example commit
+                "
+            ),
+            &None,
+        );
+        test_subject_not_seperate_from_body(
+            indoc!(
+                "
+                Another example
+
+                Disabling this specific lint - Co-authored
+
+                Co-authored-by: Someone Else <someone@example.com>
+                Co-authored-by: Someone Else <someone@example.com>
+                "
+            ),
+            &None,
+        );
+    }
+
+    #[test]
+    fn single_line_with_trailing_newline() {
+        test_subject_not_seperate_from_body("An example commit\n", &None);
+    }
+
+    #[test]
+    fn single_line() {
+        test_subject_not_seperate_from_body("An example commit", &None);
+    }
+
+    #[test]
+    fn gutter_missing() {
+        test_subject_not_seperate_from_body(
+            indoc!(
+                "
+                An example commit
+                This is an example commit
+                "
+            ),
+            &Some(Problem::new(
+                indoc!(
+                    "
+                    Your commit is not well formed
+
+                    To fix this separate subject from body with a blank line
+
+                    For example:
+
+                    Aligns time sprondle
+
+                    The time sprondle is drifting backwards in the current
+                    configuration, this corrects that.
+                    "
+                )
+                .into(),
+                Code::SubjectNotSeparateFromBody,
+            )),
+        );
+        test_subject_not_seperate_from_body(
+            indoc!(
+                "
+                An example commit
+                This is an example commit
+                It has more lines
+                It has even more lines
+                "
+            ),
+            &Some(Problem::new(
+                indoc!(
+                    "
+                    Your commit is not well formed
+
+                    To fix this separate subject from body with a blank line
+
+                    For example:
+
+                    Aligns time sprondle
+
+                    The time sprondle is drifting backwards in the current
+                    configuration, this corrects that.
+                    "
+                )
+                .into(),
+                Code::SubjectNotSeparateFromBody,
+            )),
+        );
+    }
+
+    fn test_subject_not_seperate_from_body(message: &str, expected: &Option<Problem>) {
+        let actual = &lint(&CommitMessage::new(message.into()));
+        assert_eq!(
+            actual, expected,
+            "Message {:?} should have returned {:?}, found {:?}",
+            message, expected, actual
+        );
+    }
+}

--- a/usage/lints/git-mit-toml.md
+++ b/usage/lints/git-mit-toml.md
@@ -92,6 +92,7 @@ git add demo.txt
 echo "
 [mit.lint]
 " > .git-mit.toml
+
 git commit -m "No ID"
 ```
 
@@ -101,19 +102,17 @@ You can also enforce a lint being off
 
 ``` bash
 mktemp > demo.txt
-git add demo.txt
 
 echo "
 [mit.lint]
 \"duplicated-trailers\" = false
 " > .git-mit.toml
 
-echo  > message
-git commit -m "Another example
-
-Disabling this specific lint - Co-authored
-
-Co-authored-by: Someone Else <someone@example.com>
-Co-authored-by: Someone Else <someone@example.com>
+git commit -a -m "Another example\
+\
+Disabling this specific lint - Co-authored\
+\
+Co-authored-by: Someone Else <someone@example.com>\
+Co-authored-by: Someone Else <someone@example.com>\
 "
 ```

--- a/usage/lints/jira-issue-key.md
+++ b/usage/lints/jira-issue-key.md
@@ -95,10 +95,7 @@ But you can with one
 mktemp > demo.txt
 git add demo.txt
 
-git commit -m "Enabled the lint
-
-JRA-123
-"
+git commit -m "$(printf "Enabled the lint\n\nJRA-123")"
 ```
 
 ## Disabling this specific lint

--- a/usage/lints/status.md
+++ b/usage/lints/status.md
@@ -21,10 +21,12 @@ ln -s "$(command -v mit-prepare-commit-msg)" .git/hooks/prepare-commit-msg
 You can list all the available lints with a handy command
 
 ``` bash
+echo git mit-config lint available
 ACTUAL="$(git mit-config lint available)"
 EXPECTED="duplicated-trailers
 pivotal-tracker-id-missing
-jira-issue-key-missing"
+jira-issue-key-missing
+subject-not-separated-from-body"
 
 diff <(printf "$ACTUAL") <(printf "$EXPECTED")
 ```
@@ -34,8 +36,10 @@ diff <(printf "$ACTUAL") <(printf "$EXPECTED")
 You can list all the enabled lints with a handy command
 
 ``` bash
+echo git mit-config lint enabled
 ACTUAL="$(git mit-config lint enabled)"
-EXPECTED="duplicated-trailers"
+EXPECTED="duplicated-trailers
+subject-not-separated-from-body"
 
 diff <(printf "$ACTUAL") <(printf "$EXPECTED")
 ```

--- a/usage/lints/subject-not-seperate-body.md
+++ b/usage/lints/subject-not-seperate-body.md
@@ -1,4 +1,4 @@
-# Pivotal Tracker Lints
+# Subject Not seperate from body
 
 ## Setup
 
@@ -52,67 +52,74 @@ se:
   name: Someone Else
   email: someone@example.com" > git-mit.yml
 
-git-mit -c git-mit.yml se
+git-mit -c git-mit.yml ae se
 echo "git-mit.yml" > .gitignore
 git add .
-git commit -m "Add a git ignore"
-
 ```
 
 ## Default setting
 
-Without enabling the lint can make commits without an ID
-
-``` bash
-mktemp > demo.txt
-git add .
-git commit -m "Enabling a lint"
-```
-
-## Enabling this specific lint
-
-To enable it run
-
-``` bash
-git mit-config lint enable pivotal-tracker-id-missing
-```
-
-After enabling the lint you can't commit without a issue id
+This lint is enabled by default, with it on you can't commit without a gutter between the subject and the body.
 
 ``` bash
 mktemp > demo.txt
 git add demo.txt
 
-if git commit -m "I am not made" ; then
+
+if git commit -m "Example poorly formed commit
+Notice how there's no gap here" ; then
     echo "This never happens" 
     exit 1
 fi
 ```
 
-But you can with one
+You must put a gutter in like this
 
 ``` bash
 mktemp > demo.txt
 git add demo.txt
 
-git commit -m "Enabled the lint\
-\
-[#87654321]\
-"
+
+git commit -m "$(printf "Example well formed commit\n\nNotice how there's a gap here")"
 ```
+
 
 ## Disabling this specific lint
 
 You can also disable the lint
 
 ``` bash
-git mit-config lint disable pivotal-tracker-id-missing
+git mit-config lint disable subject-not-separated-from-body
 ```
 
-You'll be able to commit without an ID
+You'll be able to commit with a poorly formed commit
 
 ``` bash
 mktemp > demo.txt
 git add demo.txt
-git commit -m "Disabling the lint"
+
+git commit -m "Example poorly formed commit\
+Notice how there's no gap here"
+```
+
+## Enabling this lint again
+
+To enable it run
+
+``` bash
+git mit-config lint enable subject-not-separated-from-body
+```
+
+Then the lints are enabled again
+
+``` bash
+mktemp > demo.txt
+git add demo.txt
+
+
+if git commit -m "Example poorly formed commit
+Notice how there's no gap here" ; then
+    echo "This never happens" 
+    exit 1
+fi
 ```

--- a/usage/mit/mit.md
+++ b/usage/mit/mit.md
@@ -76,9 +76,7 @@ You can't commit without an author set
 mktemp > demo.txt
 git add demo.txt
 
-if git commit -m "Demo 1
-
-Full Demo" ; then
+if git commit -m "$(printf "Demo 1\n\nFull Demo")" ; then
     echo "This never happens" 
     exit 1
 fi
@@ -95,17 +93,10 @@ mktemp > demo.txt
 git add demo.txt
 
 git mit ae
-git commit -m "Demo 2
-
-Full Demo"
+git commit -m "$(printf "Demo 2\n\nFull Demo")"
 
 ACTUAL="$(last_commit)"
-EXPECTED="author: Anyone Else anyone@example.com
-signed: 
-commit:
-Demo 2
-
-Full Demo"
+EXPECTED="$(printf "author: Anyone Else anyone@example.com\nsigned: \ncommit:\nDemo 2\n\nFull Demo")"
 diff <(echo "$ACTUAL") <(echo "$EXPECTED")
 ```
 
@@ -116,13 +107,11 @@ mktemp > demo.txt
 git add demo.txt
 
 git mit se ae
-git commit -m "Demo 3
-
-Full Demo"
+git commit -m "$(printf "Demo 3\n\nFull Demo\n")"
 ACTUAL="$(last_commit)"
-EXPECTED="$(printf "author: Someone Else someone@example.com\nsigned: \ncommit:\nDemo 3\nFull Demo\n\nCo-authored-by: Anyone Else <anyone@example.com>\n")"
+EXPECTED="$(printf "author: Someone Else someone@example.com\nsigned: \ncommit:\nDemo 3\n\nFull Demo\n\nCo-authored-by: Anyone Else <anyone@example.com>\n")"
 
-diff <(echo "$EXPECTED") <(echo "$ACTUAL")
+diff  <(echo "$EXPECTED") <(echo "$ACTUAL")
 ```
 
 We even support mobbing
@@ -132,11 +121,9 @@ mktemp > demo.txt
 git add demo.txt
 
 git mit bt se ae
-git commit -m "Demo 5
-
-Full Demo"
+git commit -m "$(printf "Demo 5\n\nFull Demo")"
 ACTUAL="$(last_commit)"
-EXPECTED="$(printf "author: Billie Thompson billie@example.com\nsigned: \ncommit:\nDemo 5\nFull Demo\n\nCo-authored-by: Someone Else <someone@example.com>\n\nCo-authored-by: Anyone Else <anyone@example.com>\n")"
+EXPECTED="$(printf "author: Billie Thompson billie@example.com\nsigned: \ncommit:\nDemo 5\n\nFull Demo\n\nCo-authored-by: Someone Else <someone@example.com>\n\nCo-authored-by: Anyone Else <anyone@example.com>\n")"
 
 diff <(echo "$EXPECTED") <(echo "$ACTUAL")
 ```
@@ -148,11 +135,9 @@ mktemp > demo.txt
 git add demo.txt
 
 git mit bt
-git commit -S -m "Demo 6
-
-Full Demo"
+git commit -S -m "$(printf "Demo 6\n\nFull Demo")"
 ACTUAL="$(last_commit)"
-EXPECTED="$(printf "author: Billie Thompson billie@example.com\nsigned: Billie Thompson <billie@example.com>\ncommit:\nDemo 6\nFull Demo\n\n")"
+EXPECTED="$(printf "author: Billie Thompson billie@example.com\nsigned: Billie Thompson <billie@example.com>\ncommit:\nDemo 6\n\nFull Demo\n\n")"
 
 diff <(echo "$EXPECTED") <(echo "$ACTUAL")
 ```

--- a/usage/relates-to/mit.md
+++ b/usage/relates-to/mit.md
@@ -80,11 +80,9 @@ Without setting the variable nothing happens
 mktemp > demo.txt
 git add demo.txt
 
-git commit -m "Demo 1
-
-Full Demo"
+git commit -m "Demo 1 Full Demo"
 ACTUAL="$(last_commit)"
-EXPECTED="$(printf "author: Someone Else someone@example.com\nsigned: \ncommit:\nDemo 1\nFull Demo\n\n")"
+EXPECTED="$(printf "author: Someone Else someone@example.com\nsigned: \ncommit:\nDemo 1 Full Demo\n\n")"
 
 diff <(echo "$EXPECTED") <(echo "$ACTUAL")
 ```
@@ -96,11 +94,9 @@ mktemp > demo.txt
 git add demo.txt
 
 git mit-relates-to "#[#12343567]"
-git commit -m "Demo 2
-
-Full Demo"
+git commit -m "Demo 2 Full Demo"
 ACTUAL="$(last_commit)"
-EXPECTED="$(printf "author: Someone Else someone@example.com\nsigned: \ncommit:\nDemo 2\nFull Demo\n\nRelates-to: #[#12343567]\n")"
+EXPECTED="$(printf "author: Someone Else someone@example.com\nsigned: \ncommit:\nDemo 2 Full Demo\n\nRelates-to: #[#12343567]\n")"
 
 diff <(echo "$EXPECTED") <(echo "$ACTUAL")
 ```


### PR DESCRIPTION
This adds a subject must have a gutter between it and the body lint.
It's enabled by default.

Relates-to: #171
