### PR TITLE
The github lint is missing from available, this fixes that

### DIFF
--- a/mit-commit-message-lints/src/lints/lib/lint.rs
+++ b/mit-commit-message-lints/src/lints/lib/lint.rs
@@ -57,13 +57,22 @@ impl Lint {
 
 impl Lint {
     pub fn iterator() -> impl Iterator<Item = Lint> {
-        static LINTS: [Lint; 4] = [
+        static LINTS: [Lint; 5] = [
             Lint::DuplicatedTrailers,
             Lint::PivotalTrackerIdMissing,
             Lint::JiraIssueKeyMissing,
             Lint::SubjectNotSeparateFromBody,
+            Lint::GitHubIdMissing,
         ];
         LINTS.iter().copied()
+    }
+
+    #[must_use]
+    pub fn enabled_by_default(self) -> bool {
+        static DEFAULT_ENABLED_LINTS: [Lint; 2] =
+            [Lint::DuplicatedTrailers, Lint::SubjectNotSeparateFromBody];
+
+        DEFAULT_ENABLED_LINTS.contains(&self)
     }
 
     #[must_use]
@@ -120,6 +129,30 @@ mod tests_lints {
             "pivotal-tracker-id-missing",
             &format!("{}", Lint::PivotalTrackerIdMissing)
         )
+    }
+
+    #[test]
+    fn i_can_get_all_the_lints() {
+        let all: Vec<Lint> = Lint::iterator().collect();
+        assert_eq!(
+            all,
+            vec![
+                Lint::DuplicatedTrailers,
+                Lint::PivotalTrackerIdMissing,
+                Lint::JiraIssueKeyMissing,
+                Lint::SubjectNotSeparateFromBody,
+                Lint::GitHubIdMissing,
+            ]
+        )
+    }
+
+    #[test]
+    fn i_can_get_if_a_lint_is_enabled_by_default() {
+        assert_eq!(Lint::DuplicatedTrailers.enabled_by_default(), true);
+        assert_eq!(Lint::PivotalTrackerIdMissing.enabled_by_default(), false);
+        assert_eq!(Lint::JiraIssueKeyMissing.enabled_by_default(), false);
+        assert_eq!(Lint::SubjectNotSeparateFromBody.enabled_by_default(), true);
+        assert_eq!(Lint::GitHubIdMissing.enabled_by_default(), false);
     }
 }
 

--- a/mit-commit-message-lints/src/lints/lib/lints.rs
+++ b/mit-commit-message-lints/src/lints/lib/lints.rs
@@ -74,16 +74,11 @@ impl Lints {
     /// If reading from the VCS fails
     pub fn try_from_vcs(config: &mut dyn Vcs) -> Result<Lints, Error> {
         Ok(Lints::new(
-            vec![
-                get_config_or_default(config, Lint::DuplicatedTrailers, true)?,
-                get_config_or_default(config, Lint::PivotalTrackerIdMissing, false)?,
-                get_config_or_default(config, Lint::JiraIssueKeyMissing, false)?,
-                get_config_or_default(config, Lint::GitHubIdMissing, false)?,
-                get_config_or_default(config, Lint::SubjectNotSeparateFromBody, true)?,
-            ]
-            .into_iter()
-            .flatten()
-            .collect(),
+            Lint::iterator()
+                .flat_map(|lint| {
+                    get_config_or_default(config, lint, lint.enabled_by_default()).transpose()
+                })
+                .collect::<Result<BTreeSet<Lint>, Error>>()?,
         ))
     }
 

--- a/usage/lints/status.md
+++ b/usage/lints/status.md
@@ -26,6 +26,7 @@ ACTUAL="$(git mit-config lint available)"
 EXPECTED="duplicated-trailers
 pivotal-tracker-id-missing
 jira-issue-key-missing
+github-id-missing
 subject-not-separated-from-body"
 
 diff <(printf "$ACTUAL") <(printf "$EXPECTED")


### PR DESCRIPTION
We also spend some time in this PR centralising all the places we do
assorted listing of lints into a single place, so this is less likely to
happen in the future.
