### PR TITLE
Adds Subject Longer than 72 Characters

### DIFF
--- a/mit-commit-message-lints/src/lints/lib/lint.rs
+++ b/mit-commit-message-lints/src/lints/lib/lint.rs
@@ -12,6 +12,7 @@ pub enum Lint {
     JiraIssueKeyMissing,
     GitHubIdMissing,
     SubjectNotSeparateFromBody,
+    SubjectLongerThan72Characters,
 }
 
 pub(crate) const CONFIG_KEY_PREFIX: &str = "mit.lint";
@@ -51,26 +52,31 @@ impl Lint {
             Lint::JiraIssueKeyMissing => lib::missing_jira_issue_key::CONFIG,
             Lint::GitHubIdMissing => lib::missing_github_id::CONFIG,
             Lint::SubjectNotSeparateFromBody => lib::subject_not_seperate_from_body::CONFIG,
+            Lint::SubjectLongerThan72Characters => lib::subject_longer_than_72_characters::CONFIG,
         }
     }
 }
 
 impl Lint {
     pub fn iterator() -> impl Iterator<Item = Lint> {
-        static LINTS: [Lint; 5] = [
+        static LINTS: [Lint; 6] = [
             Lint::DuplicatedTrailers,
             Lint::PivotalTrackerIdMissing,
             Lint::JiraIssueKeyMissing,
             Lint::SubjectNotSeparateFromBody,
             Lint::GitHubIdMissing,
+            Lint::SubjectLongerThan72Characters,
         ];
         LINTS.iter().copied()
     }
 
     #[must_use]
     pub fn enabled_by_default(self) -> bool {
-        static DEFAULT_ENABLED_LINTS: [Lint; 2] =
-            [Lint::DuplicatedTrailers, Lint::SubjectNotSeparateFromBody];
+        static DEFAULT_ENABLED_LINTS: [Lint; 3] = [
+            Lint::DuplicatedTrailers,
+            Lint::SubjectNotSeparateFromBody,
+            Lint::SubjectLongerThan72Characters,
+        ];
 
         DEFAULT_ENABLED_LINTS.contains(&self)
     }
@@ -89,6 +95,9 @@ impl Lint {
             Lint::GitHubIdMissing => lib::missing_github_id::lint(commit_message),
             Lint::SubjectNotSeparateFromBody => {
                 lib::subject_not_seperate_from_body::lint(commit_message)
+            }
+            Lint::SubjectLongerThan72Characters => {
+                lib::subject_longer_than_72_characters::lint(commit_message)
             }
         }
     }
@@ -142,6 +151,7 @@ mod tests_lints {
                 Lint::JiraIssueKeyMissing,
                 Lint::SubjectNotSeparateFromBody,
                 Lint::GitHubIdMissing,
+                Lint::SubjectLongerThan72Characters
             ]
         )
     }

--- a/mit-commit-message-lints/src/lints/lib/lints.rs
+++ b/mit-commit-message-lints/src/lints/lib/lints.rs
@@ -148,7 +148,9 @@ mod tests {
 
     use crate::{external::InMemory, lints::Lint::DuplicatedTrailers};
 
-    use crate::lints::lib::lint::Lint::{GitHubIdMissing, SubjectNotSeparateFromBody};
+    use crate::lints::lib::lint::Lint::{
+        GitHubIdMissing, SubjectLongerThan72Characters, SubjectNotSeparateFromBody,
+    };
     use std::convert::TryInto;
 
     #[test]
@@ -235,6 +237,7 @@ mod tests {
         let mut lints = BTreeSet::new();
         lints.insert(DuplicatedTrailers);
         lints.insert(SubjectNotSeparateFromBody);
+        lints.insert(SubjectLongerThan72Characters);
 
         let expected = Lints::new(lints);
 
@@ -265,6 +268,7 @@ mod tests {
         lints.insert(DuplicatedTrailers);
         lints.insert(PivotalTrackerIdMissing);
         lints.insert(SubjectNotSeparateFromBody);
+        lints.insert(SubjectLongerThan72Characters);
         let expected = Lints::new(lints);
 
         assert_eq!(
@@ -292,6 +296,7 @@ mod tests {
 
         let mut lints = BTreeSet::new();
         lints.insert(SubjectNotSeparateFromBody);
+        lints.insert(SubjectLongerThan72Characters);
         let expected = Lints::new(lints);
 
         assert_eq!(
@@ -309,6 +314,7 @@ mod tests {
         let mut lints = BTreeSet::new();
         lints.insert(DuplicatedTrailers);
         lints.insert(SubjectNotSeparateFromBody);
+        lints.insert(SubjectLongerThan72Characters);
         let expected = Lints::new(lints);
 
         let actual = Lints::try_from_vcs(&mut config).expect("Failed to read lints from VCS");
@@ -329,6 +335,7 @@ mod tests {
         let actual = Lints::try_from_vcs(&mut config).expect("Failed to read lints from VCS");
         let mut lints = BTreeSet::new();
         lints.insert(SubjectNotSeparateFromBody);
+        lints.insert(SubjectLongerThan72Characters);
         let expected: Lints = Lints::new(lints);
 
         assert_eq!(
@@ -347,6 +354,7 @@ mod tests {
         let mut lints = BTreeSet::new();
         lints.insert(DuplicatedTrailers);
         lints.insert(SubjectNotSeparateFromBody);
+        lints.insert(SubjectLongerThan72Characters);
         let expected = Lints::new(lints);
 
         let actual = Lints::try_from_vcs(&mut config).expect("Failed to read lints from VCS");
@@ -368,6 +376,7 @@ mod tests {
         lints.insert(DuplicatedTrailers);
         lints.insert(PivotalTrackerIdMissing);
         lints.insert(SubjectNotSeparateFromBody);
+        lints.insert(SubjectLongerThan72Characters);
         let expected = Lints::new(lints);
 
         let actual = Lints::try_from_vcs(&mut config).expect("Failed to read lints from VCS");
@@ -389,6 +398,7 @@ mod tests {
         lints.insert(DuplicatedTrailers);
         lints.insert(GitHubIdMissing);
         lints.insert(SubjectNotSeparateFromBody);
+        lints.insert(SubjectLongerThan72Characters);
         let expected = Lints::new(lints);
 
         let actual = Lints::try_from_vcs(&mut config).expect("Failed to read lints from VCS");
@@ -410,6 +420,7 @@ mod tests {
         lints.insert(DuplicatedTrailers);
         lints.insert(JiraIssueKeyMissing);
         lints.insert(SubjectNotSeparateFromBody);
+        lints.insert(SubjectLongerThan72Characters);
         let expected = Lints::new(lints);
 
         let actual = Lints::try_from_vcs(&mut config).expect("Failed to read lints from VCS");
@@ -432,6 +443,7 @@ mod tests {
         let mut lints = BTreeSet::new();
         lints.insert(DuplicatedTrailers);
         lints.insert(SubjectNotSeparateFromBody);
+        lints.insert(SubjectLongerThan72Characters);
         let expected = Lints::new(lints);
 
         assert_eq!(

--- a/mit-commit-message-lints/src/lints/lib/mod.rs
+++ b/mit-commit-message-lints/src/lints/lib/mod.rs
@@ -2,6 +2,7 @@ mod commit_message;
 mod error;
 mod lint;
 mod lints;
+mod subject_longer_than_72_characters;
 mod subject_not_seperate_from_body;
 mod trailer;
 

--- a/mit-commit-message-lints/src/lints/lib/problem.rs
+++ b/mit-commit-message-lints/src/lints/lib/problem.rs
@@ -32,4 +32,5 @@ pub enum Code {
     JiraIssueKeyMissing,
     GitHubIdMissing,
     SubjectNotSeparateFromBody,
+    SubjectLongerThan72Characters,
 }

--- a/mit-commit-message-lints/src/lints/lib/subject_longer_than_72_characters.rs
+++ b/mit-commit-message-lints/src/lints/lib/subject_longer_than_72_characters.rs
@@ -1,0 +1,353 @@
+use crate::lints::lib::problem::Code;
+use crate::lints::lib::{CommitMessage, Problem};
+use indoc::indoc;
+
+pub(crate) const CONFIG: &str = "subject-longer-than-72-characters";
+
+const HELP_MESSAGE: &str = indoc!(
+    "
+    Your commit is not well formed
+
+    Please keep the subject line 72 characters or under
+    "
+);
+
+fn has_subject_longer_than_72_chars(commit_message: &CommitMessage) -> bool {
+    commit_message.get_subject().len() > 72
+}
+
+pub(crate) fn lint(commit_message: &CommitMessage) -> Option<Problem> {
+    if has_subject_longer_than_72_chars(commit_message) {
+        Some(Problem::new(
+            HELP_MESSAGE.into(),
+            Code::SubjectLongerThan72Characters,
+        ))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::wildcard_imports)]
+
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn shorter_than_72_characters() {
+        test_subject_longer_than_72_characters(&"x".repeat(72), &None);
+    }
+
+    #[test]
+    fn shorter_than_72_characters_with_a_new_line() {
+        test_subject_longer_than_72_characters(&format!("{}\n", "x".repeat(72)), &None);
+    }
+
+    #[test]
+    fn shorter_than_72_characters_with_realistic_trailer_and_a_body() {
+        let message = indoc!(
+            "
+            Remove duplicated function
+            # Short (50 chars or less) summary of changes
+            #
+            # More detailed explanatory text, if necessary.  Wrap it to
+            # about 72 characters or so.  In some contexts, the first
+            # line is treated as the subject of an email and the rest of
+            # the text as the body.  The blank line separating the
+            # summary from the body is critical (unless you omit the body
+            # entirely); tools like rebase can get confused if you run
+            # the two together.
+            #
+            # Further paragraphs come after blank lines.
+            #
+            #   - Bullet points are okay, too
+            #
+            #   - Typically a hyphen or asterisk is used for the bullet,
+            #     preceded by a single space, with blank lines in
+            #     between, but conventions vary here
+
+            # Bitte geben Sie eine Commit-Beschreibung f\u{00FC}r Ihre \u{00C4}nderungen ein. Zeilen,
+            # die mit '#' beginnen, werden ignoriert, und eine leere Beschreibung
+            # bricht den Commit ab.
+            #
+            # Auf Branch character-limit
+            # Zum Commit vorgemerkte \u{00C4}nderungen:
+            #	ge\u{00E4}ndert:       mit-commit-message-lints/src/lints/lib/missing_pivotal_tracker_id.rs
+            #
+            # ------------------------ >8 ------------------------
+            # \u{00C4}ndern oder entfernen Sie nicht die obige Zeile.
+            # Alles unterhalb von ihr wird ignoriert.
+            diff --git a/mit-commit-message-lints/src/lints/lib/missing_pivotal_tracker_id.rs b/mit-commit-message-lints/src/lints/lib/missing_pivotal_tracker_id.rs
+            index 5a83784..ebaee48 100644
+            --- a/mit-commit-message-lints/src/lints/lib/missing_pivotal_tracker_id.rs
+            +++ b/mit-commit-message-lints/src/lints/lib/missing_pivotal_tracker_id.rs
+            -fn has_missing_pivotal_tracker_id(commit_message: &CommitMessage) -> bool {
+            -    has_no_pivotal_tracker_id(commit_message)
+            -}
+            -
+             fn has_no_pivotal_tracker_id(text: &CommitMessage) -> bool {
+                 let re = Regex::new(REGEX_PIVOTAL_TRACKER_ID).unwrap();
+                 !text.matches_pattern(&re)
+             }
+
+             pub(crate) fn lint(commit_message: &CommitMessage) -> Option<Problem> {
+            -    if has_missing_pivotal_tracker_id(commit_message) {
+            +    if has_no_pivotal_tracker_id(commit_message) {
+                     Some(Problem::new(
+                         PIVOTAL_TRACKER_HELP.into(),
+                         Code::PivotalTrackerIdMissing,
+
+
+            "
+        );
+        test_subject_longer_than_72_characters(
+            &format!("{}\n\n{}", "x".repeat(72), message),
+            &None,
+        );
+    }
+
+    #[test]
+    fn shorter_than_72_characters_with_realistic_trailer() {
+        let message = indoc!(
+            "
+            # Short (50 chars or less) summary of changes
+            #
+            # More detailed explanatory text, if necessary.  Wrap it to
+            # about 72 characters or so.  In some contexts, the first
+            # line is treated as the subject of an email and the rest of
+            # the text as the body.  The blank line separating the
+            # summary from the body is critical (unless you omit the body
+            # entirely); tools like rebase can get confused if you run
+            # the two together.
+            #
+            # Further paragraphs come after blank lines.
+            #
+            #   - Bullet points are okay, too
+            #
+            #   - Typically a hyphen or asterisk is used for the bullet,
+            #     preceded by a single space, with blank lines in
+            #     between, but conventions vary here
+
+            # Bitte geben Sie eine Commit-Beschreibung f\u{00FC}r Ihre \u{00C4}nderungen ein. Zeilen,
+            # die mit '#' beginnen, werden ignoriert, und eine leere Beschreibung
+            # bricht den Commit ab.
+            #
+            # Auf Branch character-limit
+            # Zum Commit vorgemerkte \u{00C4}nderungen:
+            #	ge\u{00E4}ndert:       mit-commit-message-lints/src/lints/lib/missing_pivotal_tracker_id.rs
+            #
+            # ------------------------ >8 ------------------------
+            # \u{00C4}ndern oder entfernen Sie nicht die obige Zeile.
+            # Alles unterhalb von ihr wird ignoriert.
+            diff --git a/mit-commit-message-lints/src/lints/lib/missing_pivotal_tracker_id.rs b/mit-commit-message-lints/src/lints/lib/missing_pivotal_tracker_id.rs
+            index 5a83784..ebaee48 100644
+            --- a/mit-commit-message-lints/src/lints/lib/missing_pivotal_tracker_id.rs
+            +++ b/mit-commit-message-lints/src/lints/lib/missing_pivotal_tracker_id.rs
+            -fn has_missing_pivotal_tracker_id(commit_message: &CommitMessage) -> bool {
+            -    has_no_pivotal_tracker_id(commit_message)
+            -}
+            -
+             fn has_no_pivotal_tracker_id(text: &CommitMessage) -> bool {
+                 let re = Regex::new(REGEX_PIVOTAL_TRACKER_ID).unwrap();
+                 !text.matches_pattern(&re)
+             }
+
+             pub(crate) fn lint(commit_message: &CommitMessage) -> Option<Problem> {
+            -    if has_missing_pivotal_tracker_id(commit_message) {
+            +    if has_no_pivotal_tracker_id(commit_message) {
+                     Some(Problem::new(
+                         PIVOTAL_TRACKER_HELP.into(),
+                         Code::PivotalTrackerIdMissing,
+
+
+            "
+        );
+        test_subject_longer_than_72_characters(
+            &format!("{}\n\n{}", "x".repeat(72), message),
+            &None,
+        );
+    }
+
+    #[test]
+    fn longer_than_72_characters() {
+        test_subject_longer_than_72_characters(
+            &"x".repeat(73),
+            &Some(Problem::new(
+                indoc!(
+                    "
+                    Your commit is not well formed
+
+                    Please keep the subject line 72 characters or under
+                    "
+                )
+                .into(),
+                Code::SubjectLongerThan72Characters,
+            )),
+        );
+    }
+
+    #[test]
+    fn longer_than_72_characters_and_a_newline() {
+        test_subject_longer_than_72_characters(
+            &format!("{}\n", "x".repeat(73)),
+            &Some(Problem::new(
+                indoc!(
+                    "
+                    Your commit is not well formed
+
+                    Please keep the subject line 72 characters or under
+                    "
+                )
+                .into(),
+                Code::SubjectLongerThan72Characters,
+            )),
+        );
+    }
+
+    #[test]
+    fn longer_than_72_characters_and_a_body() {
+        let message = indoc!(
+            "
+            Remove duplicated function
+            # Short (50 chars or less) summary of changes
+            #
+            # More detailed explanatory text, if necessary.  Wrap it to
+            # about 72 characters or so.  In some contexts, the first
+            # line is treated as the subject of an email and the rest of
+            # the text as the body.  The blank line separating the
+            # summary from the body is critical (unless you omit the body
+            # entirely); tools like rebase can get confused if you run
+            # the two together.
+            #
+            # Further paragraphs come after blank lines.
+            #
+            #   - Bullet points are okay, too
+            #
+            #   - Typically a hyphen or asterisk is used for the bullet,
+            #     preceded by a single space, with blank lines in
+            #     between, but conventions vary here
+
+            # Bitte geben Sie eine Commit-Beschreibung f\u{00FC}r Ihre \u{00C4}nderungen ein. Zeilen,
+            # die mit '#' beginnen, werden ignoriert, und eine leere Beschreibung
+            # bricht den Commit ab.
+            #
+            # Auf Branch character-limit
+            # Zum Commit vorgemerkte \u{00C4}nderungen:
+            #	ge\u{00E4}ndert:       mit-commit-message-lints/src/lints/lib/missing_pivotal_tracker_id.rs
+            #
+            # ------------------------ >8 ------------------------
+            # \u{00C4}ndern oder entfernen Sie nicht die obige Zeile.
+            # Alles unterhalb von ihr wird ignoriert.
+            diff --git a/mit-commit-message-lints/src/lints/lib/missing_pivotal_tracker_id.rs b/mit-commit-message-lints/src/lints/lib/missing_pivotal_tracker_id.rs
+            index 5a83784..ebaee48 100644
+            --- a/mit-commit-message-lints/src/lints/lib/missing_pivotal_tracker_id.rs
+            +++ b/mit-commit-message-lints/src/lints/lib/missing_pivotal_tracker_id.rs
+            -fn has_missing_pivotal_tracker_id(commit_message: &CommitMessage) -> bool {
+            -    has_no_pivotal_tracker_id(commit_message)
+            -}
+            -
+             fn has_no_pivotal_tracker_id(text: &CommitMessage) -> bool {
+                 let re = Regex::new(REGEX_PIVOTAL_TRACKER_ID).unwrap();
+                 !text.matches_pattern(&re)
+             }
+
+             pub(crate) fn lint(commit_message: &CommitMessage) -> Option<Problem> {
+            -    if has_missing_pivotal_tracker_id(commit_message) {
+            +    if has_no_pivotal_tracker_id(commit_message) {
+                     Some(Problem::new(
+                         PIVOTAL_TRACKER_HELP.into(),
+                         Code::PivotalTrackerIdMissing,
+
+
+            "
+        );
+        test_subject_longer_than_72_characters(
+            &format!("{}\n\n{}", "x".repeat(73), message),
+            &Some(Problem::new(
+                indoc!(
+                    "
+                    Your commit is not well formed
+
+                    Please keep the subject line 72 characters or under
+                    "
+                )
+                .into(),
+                Code::SubjectLongerThan72Characters,
+            )),
+        );
+    }
+
+    #[test]
+    fn longer_than_72_characters_with_realistic_tail() {
+        let message = indoc!(
+            "
+            # Short (50 chars or less) summary of changes
+            #
+            # More detailed explanatory text, if necessary.  Wrap it to
+            # about 72 characters or so.  In some contexts, the first
+            # line is treated as the subject of an email and the rest of
+            # the text as the body.  The blank line separating the
+            # summary from the body is critical (unless you omit the body
+            # entirely); tools like rebase can get confused if you run
+            # the two together.
+            #
+            # Further paragraphs come after blank lines.
+            #
+            #   - Bullet points are okay, too
+            #
+            #   - Typically a hyphen or asterisk is used for the bullet,
+            #     preceded by a single space, with blank lines in
+            #     between, but conventions vary here
+
+            # Bitte geben Sie eine Commit-Beschreibung f\u{00FC}r Ihre \u{00C4}nderungen ein. Zeilen,
+            # die mit '#' beginnen, werden ignoriert, und eine leere Beschreibung
+            # bricht den Commit ab.
+            #
+            # Auf Branch character-limit
+            # Zum Commit vorgemerkte \u{00C4}nderungen:
+            #	ge\u{00E4}ndert:       mit-commit-message-lints/src/lints/lib/missing_pivotal_tracker_id.rs
+            #
+            # ------------------------ >8 ------------------------
+            # \u{00C4}ndern oder entfernen Sie nicht die obige Zeile.
+            # Alles unterhalb von ihr wird ignoriert.
+            diff --git a/mit-commit-message-lints/src/lints/lib/missing_pivotal_tracker_id.rs b/mit-commit-message-lints/src/lints/lib/missing_pivotal_tracker_id.rs
+            index 5a83784..ebaee48 100644
+            --- a/mit-commit-message-lints/src/lints/lib/missing_pivotal_tracker_id.rs
+            +++ b/mit-commit-message-lints/src/lints/lib/missing_pivotal_tracker_id.rs
+            -fn has_missing_pivotal_tracker_id(commit_message: &CommitMessage) -> bool {
+            -    has_no_pivotal_tracker_id(commit_message)
+            -}
+            -
+             fn has_no_pivotal_tracker_id(text: &CommitMessage) -> bool {
+                 let re = Regex::new(REGEX_PIVOTAL_TRACKER_ID).unwrap();
+                 !text.matches_pattern(&re)
+             }
+
+             pub(crate) fn lint(commit_message: &CommitMessage) -> Option<Problem> {
+            -    if has_missing_pivotal_tracker_id(commit_message) {
+            +    if has_no_pivotal_tracker_id(commit_message) {
+                     Some(Problem::new(
+                         PIVOTAL_TRACKER_HELP.into(),
+                         Code::PivotalTrackerIdMissing,
+
+
+            "
+        );
+        test_subject_longer_than_72_characters(
+            &format!("{}\n\n{}", "x".repeat(72), message),
+            &None,
+        );
+    }
+
+    fn test_subject_longer_than_72_characters(message: &str, expected: &Option<Problem>) {
+        let actual = &lint(&CommitMessage::new(message.into()));
+        assert_eq!(
+            actual, expected,
+            "Message {:?} should have returned {:?}, found {:?}",
+            message, expected, actual
+        );
+    }
+}

--- a/usage/lints/status.md
+++ b/usage/lints/status.md
@@ -27,7 +27,8 @@ EXPECTED="duplicated-trailers
 pivotal-tracker-id-missing
 jira-issue-key-missing
 github-id-missing
-subject-not-separated-from-body"
+subject-not-separated-from-body
+subject-longer-than-72-characters"
 
 diff <(printf "$ACTUAL") <(printf "$EXPECTED")
 ```
@@ -40,7 +41,8 @@ You can list all the enabled lints with a handy command
 echo git mit-config lint enabled
 ACTUAL="$(git mit-config lint enabled)"
 EXPECTED="duplicated-trailers
-subject-not-separated-from-body"
+subject-not-separated-from-body
+subject-longer-than-72-characters"
 
 diff <(printf "$ACTUAL") <(printf "$EXPECTED")
 ```

--- a/usage/lints/subject-longer-than-72-characters.md
+++ b/usage/lints/subject-longer-than-72-characters.md
@@ -1,4 +1,4 @@
-# Enabling and Disabling via git-mit.toml
+# Subject Not seperate from body
 
 ## Setup
 
@@ -57,56 +57,66 @@ echo "git-mit.yml" > .gitignore
 git add .
 ```
 
-## You can create a `.git-mit.toml.dist`
+## Default setting
 
-This is at the root of your repository
-
-### Enabling a lint
+This lint is enabled by default, with it on you can't commit if the subject is longer than 72 characters
 
 ``` bash
 mktemp > demo.txt
 git add demo.txt
 
-echo "
-[mit.lint]
-\"pivotal-tracker-id-missing\" = true
-" > .git-mit.toml.dist
 
-git-mit-config lint enabled
-
-if git commit -m "Missing ID" ; then
+if git commit -m "........................................................................." ; then
     echo "This never happens" 
     exit 1
 fi
 ```
 
-### Overriding `.git-mit.toml.dist` with `.git-mit.toml`
-
-You can also create a `.git-mit.toml` which takes precedence over
-`.git-mit.toml.dist`
+This is because git hides subjects that are longer than that when displaying the history. This is valid though.
 
 ``` bash
 mktemp > demo.txt
 git add demo.txt
 
-echo "
-[mit.lint]
-" > .git-mit.toml
 
-git commit -m "No ID"
+git commit -m "........................................................................"
 ```
 
-### Disabling a lint
 
-You can also enforce a lint being off
+## Disabling this specific lint
+
+You can also disable the lint
+
+``` bash
+git mit-config lint disable subject-longer-than-72-characters
+```
+
+You'll be able to commit with a poorly formed commit
 
 ``` bash
 mktemp > demo.txt
+git add demo.txt
 
-echo "
-[mit.lint]
-\"duplicated-trailers\" = false
-" > .git-mit.toml
+git commit -m "........................................................................"
+```
 
-git commit -a -m "$(printf "Another example\n\nDisabling this specific lint - Co-authored\nCo-authored-by: Someone Else <someone@example.com>Co-authored-by: Someone Else <someone@example.com>")"
+## Enabling this lint again
+
+To enable it run
+
+``` bash
+git mit-config lint enable subject-longer-than-72-characters
+```
+
+Then the lints are enabled again
+
+``` bash
+mktemp > demo.txt
+git add demo.txt
+
+
+if git commit -m "........................................................................." ; then
+    echo "This never happens" 
+    exit 1
+fi
 ```


### PR DESCRIPTION
This checks that commit lints are within the 72 character width.

Relates-to: #171
