### PR TITLE
Add a Capitalize Commit lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,34 @@ me to learn Rust. It's a bit more than that now, with lints for issues.
 
 ### Lint list
 
+#### Trailers
+
+Lints relating to trailers
+
   - **duplicated-trailers** - Detect duplicated `Signed-off-by` and
     `Co-authored-by` Trailers. *Default: `enabled`*
-  - **subject-not-separated-from-body** - If there is a body, enforce a gap between it and the subject. *Default: `enabled`*
+
+#### Git Manual Style
+
+The style from the git manual, that directly affect the experience of
+git beyond aesthetics.
+
+  - **subject-not-separated-from-body** - If there is a body, enforce a
+    gap between it and the subject. *Default: `enabled`*
+  - **subject-longer-than-72-characters** - After 72 characters, git
+    will truncate commit messages in the history view, this prevents
+    that *Default: `enabled`*
+
+#### Git Manual Style Extended
+
+The style from the git manual, that do not affect the experience of git
+beyond aesthetics
+
+  - **subject-line-not-capitalized** - Detect a subject line that is not
+    capitalised *Default: `disabled`*
+
+#### Commit Messages
+
   - **pivotal-tracker-id-missing** - Detect missing Pivotal Tracker Id
     *Default: `disabled`*
   - **jira-issue-key-missing** - Detect missing Jira Issue Key *Default:

--- a/mit-commit-message-lints/src/lints/lib/lint.rs
+++ b/mit-commit-message-lints/src/lints/lib/lint.rs
@@ -13,6 +13,7 @@ pub enum Lint {
     GitHubIdMissing,
     SubjectNotSeparateFromBody,
     SubjectLongerThan72Characters,
+    SubjectNotCapitalized,
 }
 
 pub(crate) const CONFIG_KEY_PREFIX: &str = "mit.lint";
@@ -53,19 +54,21 @@ impl Lint {
             Lint::GitHubIdMissing => lib::missing_github_id::CONFIG,
             Lint::SubjectNotSeparateFromBody => lib::subject_not_seperate_from_body::CONFIG,
             Lint::SubjectLongerThan72Characters => lib::subject_longer_than_72_characters::CONFIG,
+            Lint::SubjectNotCapitalized => lib::subject_not_capitalized::CONFIG,
         }
     }
 }
 
 impl Lint {
     pub fn iterator() -> impl Iterator<Item = Lint> {
-        static LINTS: [Lint; 6] = [
+        static LINTS: [Lint; 7] = [
             Lint::DuplicatedTrailers,
             Lint::PivotalTrackerIdMissing,
             Lint::JiraIssueKeyMissing,
             Lint::SubjectNotSeparateFromBody,
             Lint::GitHubIdMissing,
             Lint::SubjectLongerThan72Characters,
+            Lint::SubjectNotCapitalized,
         ];
         LINTS.iter().copied()
     }
@@ -99,6 +102,7 @@ impl Lint {
             Lint::SubjectLongerThan72Characters => {
                 lib::subject_longer_than_72_characters::lint(commit_message)
             }
+            Lint::SubjectNotCapitalized => lib::subject_not_capitalized::lint(commit_message),
         }
     }
 
@@ -151,7 +155,8 @@ mod tests_lints {
                 Lint::JiraIssueKeyMissing,
                 Lint::SubjectNotSeparateFromBody,
                 Lint::GitHubIdMissing,
-                Lint::SubjectLongerThan72Characters
+                Lint::SubjectLongerThan72Characters,
+                Lint::SubjectNotCapitalized
             ]
         )
     }

--- a/mit-commit-message-lints/src/lints/lib/mod.rs
+++ b/mit-commit-message-lints/src/lints/lib/mod.rs
@@ -3,6 +3,7 @@ mod error;
 mod lint;
 mod lints;
 mod subject_longer_than_72_characters;
+mod subject_not_capitalized;
 mod subject_not_seperate_from_body;
 mod trailer;
 

--- a/mit-commit-message-lints/src/lints/lib/problem.rs
+++ b/mit-commit-message-lints/src/lints/lib/problem.rs
@@ -33,4 +33,5 @@ pub enum Code {
     GitHubIdMissing,
     SubjectNotSeparateFromBody,
     SubjectLongerThan72Characters,
+    SubjectLintNotCapitalized,
 }

--- a/mit-commit-message-lints/src/lints/lib/subject_not_capitalized.rs
+++ b/mit-commit-message-lints/src/lints/lib/subject_not_capitalized.rs
@@ -1,0 +1,90 @@
+use crate::lints::lib::problem::Code;
+use crate::lints::lib::{CommitMessage, Problem};
+use indoc::indoc;
+
+pub(crate) const CONFIG: &str = "subject-line-not-capitalized";
+
+const HELP_MESSAGE: &str = indoc!(
+    "
+    You forgot to capitalise the subject
+
+    You can fix this by capitalising the first character in the subject
+    "
+);
+
+fn has_problem(commit_message: &CommitMessage) -> bool {
+    if let Some(character) = commit_message.get_subject().chars().next() {
+        return character.to_string() != character.to_uppercase().to_string();
+    }
+
+    false
+}
+
+pub(crate) fn lint(commit_message: &CommitMessage) -> Option<Problem> {
+    if has_problem(commit_message) {
+        Some(Problem::new(
+            HELP_MESSAGE.into(),
+            Code::SubjectLintNotCapitalized,
+        ))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::wildcard_imports)]
+
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn capitalised() {
+        run_test(
+            indoc!(
+                "
+                Subject Line
+                "
+            ),
+            &None,
+        );
+    }
+
+    #[test]
+    fn lower_case() {
+        run_test(
+            indoc!(
+                "
+                subject line
+                "
+            ),
+            &Some(Problem::new(
+                HELP_MESSAGE.into(),
+                Code::SubjectLintNotCapitalized,
+            )),
+        );
+    }
+
+    #[test]
+    fn numbers_are_fine() {
+        run_test(
+            indoc!(
+                "
+                1234567
+                "
+            ),
+            &None,
+        );
+    }
+
+    fn run_test(message: &str, expected: &Option<Problem>) {
+        let actual = &lint(&CommitMessage::new(message.into()));
+        assert_eq!(
+            actual, expected,
+            "Message {:?} should have returned {:?}, found {:?}",
+            message, expected, actual
+        );
+    }
+}

--- a/usage/lints/status.md
+++ b/usage/lints/status.md
@@ -28,7 +28,8 @@ pivotal-tracker-id-missing
 jira-issue-key-missing
 github-id-missing
 subject-not-separated-from-body
-subject-longer-than-72-characters"
+subject-longer-than-72-characters
+subject-line-not-capitalized"
 
 diff <(printf "$ACTUAL") <(printf "$EXPECTED")
 ```

--- a/usage/lints/subject-longer-than-72-characters.md
+++ b/usage/lints/subject-longer-than-72-characters.md
@@ -59,7 +59,8 @@ git add .
 
 ## Default setting
 
-This lint is enabled by default, with it on you can't commit if the subject is longer than 72 characters
+This lint is enabled by default, with it on you can't commit if the
+subject is longer than 72 characters
 
 ``` bash
 mktemp > demo.txt
@@ -72,7 +73,8 @@ if git commit -m "..............................................................
 fi
 ```
 
-This is because git hides subjects that are longer than that when displaying the history. This is valid though.
+This is because git hides subjects that are longer than that when
+displaying the history. This is valid though.
 
 ``` bash
 mktemp > demo.txt
@@ -81,7 +83,6 @@ git add demo.txt
 
 git commit -m "........................................................................"
 ```
-
 
 ## Disabling this specific lint
 

--- a/usage/lints/subject-not-seperate-body.md
+++ b/usage/lints/subject-not-seperate-body.md
@@ -59,7 +59,8 @@ git add .
 
 ## Default setting
 
-This lint is enabled by default, with it on you can't commit without a gutter between the subject and the body.
+This lint is enabled by default, with it on you can't commit without a
+gutter between the subject and the body.
 
 ``` bash
 mktemp > demo.txt
@@ -82,7 +83,6 @@ git add demo.txt
 
 git commit -m "$(printf "Example well formed commit\n\nNotice how there's a gap here")"
 ```
-
 
 ## Disabling this specific lint
 


### PR DESCRIPTION
This adds the capitalize commit lint. It's in the git manual so it's
probably a good thing to have as an option.

Relates-to: #171
