### PR TITLE
Standarise language in lints

### DIFF
--- a/mit-commit-message-lints/src/lints/lib/duplicate_trailers.rs
+++ b/mit-commit-message-lints/src/lints/lib/duplicate_trailers.rs
@@ -9,7 +9,7 @@ const TRAILERS_TO_CHECK_FOR_DUPLICATES: [&str; 2] = ["Signed-off-by", "Co-author
 const FIELD_SINGULAR: &str = "field";
 const FIELD_PLURAL: &str = "fields";
 
-fn has_duplicated_trailers(commit_message: &CommitMessage) -> Vec<String> {
+fn get_duplicated_trailers(commit_message: &CommitMessage) -> Vec<String> {
     TRAILERS_TO_CHECK_FOR_DUPLICATES
         .iter()
         .filter_map(|trailer| filter_without_duplicates(commit_message, trailer))
@@ -31,13 +31,12 @@ fn has_duplicated_trailer(commit_message: &CommitMessage, trailer_key: &str) -> 
 }
 
 pub(crate) fn lint(commit_message: &CommitMessage) -> Option<Problem> {
-    let duplicated_trailers = has_duplicated_trailers(commit_message);
+    let duplicated_trailers = get_duplicated_trailers(commit_message);
     if duplicated_trailers.is_empty() {
         None
     } else {
         let warning = format!(
-            "Your commit cannot have the same name duplicated in the \"{}\" {}\n\nYou can fix \
-             this by removing the duplicated field when you commit again\n",
+            "Your commit message has duplicated trailers\n\nYou can fix this by deleting the duplicated \"{}\" {}",
             duplicated_trailers.join("\", \""),
             if duplicated_trailers.len() > 1 {
                 FIELD_PLURAL
@@ -86,15 +85,7 @@ mod tests_has_duplicated_trailers {
             )
             .into(),
             &Some(Problem::new(
-                indoc!(
-                    "
-                    Your commit cannot have the same name duplicated in the \"Signed-off-by\", \
-                     \"Co-authored-by\" fields
-
-                    You can fix this by removing the duplicated field when you commit again
-                    "
-                )
-                .into(),
+                "Your commit message has duplicated trailers\n\nYou can fix this by deleting the duplicated \"Signed-off-by\", \"Co-authored-by\" fields".into(),
                 Code::DuplicatedTrailers,
             )),
         );
@@ -111,14 +102,7 @@ mod tests_has_duplicated_trailers {
             )
             .into(),
             &Some(Problem::new(
-                indoc!(
-                    "
-                    Your commit cannot have the same name duplicated in the \"Signed-off-by\" field
-
-                    You can fix this by removing the duplicated field when you commit again
-                    "
-                )
-                .into(),
+                "Your commit message has duplicated trailers\n\nYou can fix this by deleting the duplicated \"Signed-off-by\" field".into(),
                 Code::DuplicatedTrailers,
             )),
         );
@@ -135,15 +119,7 @@ mod tests_has_duplicated_trailers {
             )
             .into(),
             &Some(Problem::new(
-                indoc!(
-                    "
-                    Your commit cannot have the same name duplicated in the \"Co-authored-by\" \
-                     field
-
-                    You can fix this by removing the duplicated field when you commit again
-                    "
-                )
-                .into(),
+                "Your commit message has duplicated trailers\n\nYou can fix this by deleting the duplicated \"Co-authored-by\" field".into(),
                 Code::DuplicatedTrailers,
             )),
         );

--- a/mit-commit-message-lints/src/lints/lib/missing_github_id.rs
+++ b/mit-commit-message-lints/src/lints/lib/missing_github_id.rs
@@ -6,47 +6,32 @@ use indoc::indoc;
 
 pub(crate) const CONFIG: &str = "github-id-missing";
 
-const GITHUB_HELP_MESSAGE: &str = indoc!(
+const HELP_MESSAGE: &str = indoc!(
     "
-    Your commit is missing a GitHub ID
+    Your commit message is missing a GitHub ID
 
-    You can fix this by adding a key like the following examples
+    You can fix this by adding a ID like the following examples:
 
-    close #642
-    closes: #642
-    Closed GH-642
-    fix #642
-    This fixes #642
-    fixed #642
-    resolve #642
-    resolves #642
-    resolved #642
-    Issue #642
-
-    GitHub also supports these alternative styles of referring to IDs
-
+    #642
     GH-642
     AnUser/git-mit#642
     AnOrganisation/git-mit#642
+    fixes #642
 
-    Be careful just putting '#123' on a line by itself, as '#' is the default comment indicator
+    Be careful just putting '#642' on a line by itself, as '#' is the default comment character
     "
 );
 
-const REGEX_GITHUB_ID_REGEX: &str =
-    r"(?m)(^| )([a-zA-Z0-9_-]{3,39}/[a-zA-Z0-9-]{1,}#|GH-|#)[0-9]{1,}( |$)";
+const REGEX: &str = r"(?m)(^| )([a-zA-Z0-9_-]{3,39}/[a-zA-Z0-9-]{1,}#|GH-|#)[0-9]{1,}( |$)";
 
-fn has_missing_github_id(commit_message: &CommitMessage) -> bool {
-    let re = Regex::new(REGEX_GITHUB_ID_REGEX).unwrap();
+fn has_problem(commit_message: &CommitMessage) -> bool {
+    let re = Regex::new(REGEX).unwrap();
     !commit_message.matches_pattern(&re)
 }
 
 pub(crate) fn lint(commit_message: &CommitMessage) -> Option<Problem> {
-    if has_missing_github_id(commit_message) {
-        Some(Problem::new(
-            GITHUB_HELP_MESSAGE.into(),
-            Code::GitHubIdMissing,
-        ))
+    if has_problem(commit_message) {
+        Some(Problem::new(HELP_MESSAGE.into(), Code::GitHubIdMissing))
     } else {
         None
     }
@@ -276,35 +261,7 @@ mod tests_has_missing_github_id {
                 This is an example commit
                 "
             ),
-            &Some(Problem::new(
-                indoc!(
-                    "
-                    Your commit is missing a GitHub ID
-
-                    You can fix this by adding a key like the following examples
-
-                    close #642
-                    closes: #642
-                    Closed GH-642
-                    fix #642
-                    This fixes #642
-                    fixed #642
-                    resolve #642
-                    resolves #642
-                    resolved #642
-                    Issue #642
-
-                    GitHub also supports these alternative styles of referring to IDs
-
-                    GH-642
-                    AnUser/git-mit#642
-                    AnOrganisation/git-mit#642
-
-                    Be careful just putting '#123' on a line by itself, as '#' is the default comment indicator
-                    "
-                ).into(),
-                Code::GitHubIdMissing,
-            )),
+            &Some(Problem::new(HELP_MESSAGE.into(), Code::GitHubIdMissing)),
         );
     }
     #[test]
@@ -319,36 +276,7 @@ mod tests_has_missing_github_id {
                 H-123
                 "
             ),
-            &Some(Problem::new(
-                indoc!(
-                    "
-                    Your commit is missing a GitHub ID
-
-                    You can fix this by adding a key like the following examples
-
-                    close #642
-                    closes: #642
-                    Closed GH-642
-                    fix #642
-                    This fixes #642
-                    fixed #642
-                    resolve #642
-                    resolves #642
-                    resolved #642
-                    Issue #642
-
-                    GitHub also supports these alternative styles of referring to IDs
-
-                    GH-642
-                    AnUser/git-mit#642
-                    AnOrganisation/git-mit#642
-
-                    Be careful just putting '#123' on a line by itself, as '#' is the default comment indicator
-                    "
-                )
-                .into(),
-                Code::GitHubIdMissing,
-            )),
+            &Some(Problem::new(HELP_MESSAGE.into(), Code::GitHubIdMissing)),
         );
         test_has_missing_github_id(
             indoc!(
@@ -360,36 +288,7 @@ mod tests_has_missing_github_id {
                 git-mit#123
                 "
             ),
-            &Some(Problem::new(
-                indoc!(
-                    "
-                    Your commit is missing a GitHub ID
-
-                    You can fix this by adding a key like the following examples
-
-                    close #642
-                    closes: #642
-                    Closed GH-642
-                    fix #642
-                    This fixes #642
-                    fixed #642
-                    resolve #642
-                    resolves #642
-                    resolved #642
-                    Issue #642
-
-                    GitHub also supports these alternative styles of referring to IDs
-
-                    GH-642
-                    AnUser/git-mit#642
-                    AnOrganisation/git-mit#642
-
-                    Be careful just putting '#123' on a line by itself, as '#' is the default comment indicator
-                    "
-                )
-                .into(),
-                Code::GitHubIdMissing,
-            )),
+            &Some(Problem::new(HELP_MESSAGE.into(), Code::GitHubIdMissing)),
         );
     }
 

--- a/mit-commit-message-lints/src/lints/lib/missing_jira_issue_key.rs
+++ b/mit-commit-message-lints/src/lints/lib/missing_jira_issue_key.rs
@@ -6,27 +6,24 @@ use indoc::indoc;
 
 pub(crate) const CONFIG: &str = "jira-issue-key-missing";
 
-const JIRA_HELP_MESSAGE: &str = indoc!(
+const HELP_MESSAGE: &str = indoc!(
     "
-    Your commit is missing a JIRA Issue Key
+    Your commit message is missing a JIRA Issue Key
 
     You can fix this by adding a key like `JRA-123` to the commit message
     "
 );
 
-const REGEX_JIRA_ISSUE_KEY: &str = r"(?m)(^| )[A-Z]{2,}-[0-9]+( |$)";
+const REGEX: &str = r"(?m)(^| )[A-Z]{2,}-[0-9]+( |$)";
 
-fn has_missing_jira_issue_key(commit_message: &CommitMessage) -> bool {
-    let re = Regex::new(REGEX_JIRA_ISSUE_KEY).unwrap();
+fn has_problem(commit_message: &CommitMessage) -> bool {
+    let re = Regex::new(REGEX).unwrap();
     !commit_message.matches_pattern(&re)
 }
 
 pub(crate) fn lint(commit_message: &CommitMessage) -> Option<Problem> {
-    if has_missing_jira_issue_key(commit_message) {
-        Some(Problem::new(
-            JIRA_HELP_MESSAGE.into(),
-            Code::JiraIssueKeyMissing,
-        ))
+    if has_problem(commit_message) {
+        Some(Problem::new(HELP_MESSAGE.into(), Code::JiraIssueKeyMissing))
     } else {
         None
     }
@@ -111,17 +108,7 @@ mod tests_has_missing_jira_issue_key {
                 This is an example commit
                 "
             ),
-            &Some(Problem::new(
-                indoc!(
-                    "
-                    Your commit is missing a JIRA Issue Key
-
-                    You can fix this by adding a key like `JRA-123` to the commit message
-                    "
-                )
-                .into(),
-                Code::JiraIssueKeyMissing,
-            )),
+            &Some(Problem::new(HELP_MESSAGE.into(), Code::JiraIssueKeyMissing)),
         );
         test_has_missing_jira_issue_key(
             indoc!(
@@ -133,17 +120,7 @@ mod tests_has_missing_jira_issue_key {
                 A-123
                 "
             ),
-            &Some(Problem::new(
-                indoc!(
-                    "
-                    Your commit is missing a JIRA Issue Key
-
-                    You can fix this by adding a key like `JRA-123` to the commit message
-                    "
-                )
-                .into(),
-                Code::JiraIssueKeyMissing,
-            )),
+            &Some(Problem::new(HELP_MESSAGE.into(), Code::JiraIssueKeyMissing)),
         );
         test_has_missing_jira_issue_key(
             indoc!(
@@ -155,17 +132,7 @@ mod tests_has_missing_jira_issue_key {
                 JRA-
                 "
             ),
-            &Some(Problem::new(
-                indoc!(
-                    "
-                    Your commit is missing a JIRA Issue Key
-
-                    You can fix this by adding a key like `JRA-123` to the commit message
-                    "
-                )
-                .into(),
-                Code::JiraIssueKeyMissing,
-            )),
+            &Some(Problem::new(HELP_MESSAGE.into(), Code::JiraIssueKeyMissing)),
         );
     }
 

--- a/mit-commit-message-lints/src/lints/lib/missing_pivotal_tracker_id.rs
+++ b/mit-commit-message-lints/src/lints/lib/missing_pivotal_tracker_id.rs
@@ -6,28 +6,12 @@ use indoc::indoc;
 
 pub(crate) const CONFIG: &str = "pivotal-tracker-id-missing";
 
-const REGEX_PIVOTAL_TRACKER_ID: &str =
+const REGEX: &str =
     r"(?i)\[(((finish|fix)(ed|es)?|complete[ds]?|deliver(s|ed)?) )?#\d+([, ]#\d+)*]";
 
-fn has_no_pivotal_tracker_id(text: &CommitMessage) -> bool {
-    let re = Regex::new(REGEX_PIVOTAL_TRACKER_ID).unwrap();
-    !text.matches_pattern(&re)
-}
-
-pub(crate) fn lint(commit_message: &CommitMessage) -> Option<Problem> {
-    if has_no_pivotal_tracker_id(commit_message) {
-        Some(Problem::new(
-            PIVOTAL_TRACKER_HELP.into(),
-            Code::PivotalTrackerIdMissing,
-        ))
-    } else {
-        None
-    }
-}
-
-const PIVOTAL_TRACKER_HELP: &str = indoc!(
+const HELP_MESSAGE: &str = indoc!(
     "
-    Your commit is missing a Pivotal Tracker Id
+    Your commit message is missing a Pivotal Tracker Id
 
     You can fix this by adding the Id in one of the styles below to the commit message
     [Delivers #12345678]
@@ -39,6 +23,22 @@ const PIVOTAL_TRACKER_HELP: &str = indoc!(
     This will address [#12345884]
     "
 );
+
+fn has_problem(text: &CommitMessage) -> bool {
+    let re = Regex::new(REGEX).unwrap();
+    !text.matches_pattern(&re)
+}
+
+pub(crate) fn lint(commit_message: &CommitMessage) -> Option<Problem> {
+    if has_problem(commit_message) {
+        Some(Problem::new(
+            HELP_MESSAGE.into(),
+            Code::PivotalTrackerIdMissing,
+        ))
+    } else {
+        None
+    }
+}
 
 #[cfg(test)]
 mod tests_has_missing_pivotal_tracker_id {
@@ -362,22 +362,7 @@ mod tests_has_missing_pivotal_tracker_id {
                 "
             ),
             &Some(Problem::new(
-                indoc!(
-                    "
-                    Your commit is missing a Pivotal Tracker Id
-
-                    You can fix this by adding the Id in one of the styles below to the commit \
-                     message
-                    [Delivers #12345678]
-                    [fixes #12345678]
-                    [finishes #12345678]
-                    [#12345884 #12345678]
-                    [#12345884,#12345678]
-                    [#12345678],[#12345884]
-                    This will address [#12345884]
-                    "
-                )
-                .into(),
+                HELP_MESSAGE.into(),
                 Code::PivotalTrackerIdMissing,
             )),
         );
@@ -394,22 +379,7 @@ mod tests_has_missing_pivotal_tracker_id {
                 "
             ),
             &Some(Problem::new(
-                indoc!(
-                    "
-                    Your commit is missing a Pivotal Tracker Id
-
-                    You can fix this by adding the Id in one of the styles below to the commit \
-                     message
-                    [Delivers #12345678]
-                    [fixes #12345678]
-                    [finishes #12345678]
-                    [#12345884 #12345678]
-                    [#12345884,#12345678]
-                    [#12345678],[#12345884]
-                    This will address [#12345884]
-                    "
-                )
-                .into(),
+                HELP_MESSAGE.into(),
                 Code::PivotalTrackerIdMissing,
             )),
         );
@@ -425,21 +395,7 @@ mod tests_has_missing_pivotal_tracker_id {
             "
             ),
             &Some(Problem::new(
-                indoc!(
-                    "
-                Your commit is missing a Pivotal Tracker Id
-
-                You can fix this by adding the Id in one of the styles below to the commit message
-                [Delivers #12345678]
-                [fixes #12345678]
-                [finishes #12345678]
-                [#12345884 #12345678]
-                [#12345884,#12345678]
-                [#12345678],[#12345884]
-                This will address [#12345884]
-                "
-                )
-                .into(),
+                HELP_MESSAGE.into(),
                 Code::PivotalTrackerIdMissing,
             )),
         );

--- a/mit-commit-message-lints/src/lints/lib/subject_longer_than_72_characters.rs
+++ b/mit-commit-message-lints/src/lints/lib/subject_longer_than_72_characters.rs
@@ -6,18 +6,18 @@ pub(crate) const CONFIG: &str = "subject-longer-than-72-characters";
 
 const HELP_MESSAGE: &str = indoc!(
     "
-    Your commit is not well formed
+    Your commit message is not well formed
 
     Please keep the subject line 72 characters or under
     "
 );
 
-fn has_subject_longer_than_72_chars(commit_message: &CommitMessage) -> bool {
+fn has_problem(commit_message: &CommitMessage) -> bool {
     commit_message.get_subject().len() > 72
 }
 
 pub(crate) fn lint(commit_message: &CommitMessage) -> Option<Problem> {
-    if has_subject_longer_than_72_chars(commit_message) {
+    if has_problem(commit_message) {
         Some(Problem::new(
             HELP_MESSAGE.into(),
             Code::SubjectLongerThan72Characters,
@@ -176,14 +176,7 @@ mod tests {
         test_subject_longer_than_72_characters(
             &"x".repeat(73),
             &Some(Problem::new(
-                indoc!(
-                    "
-                    Your commit is not well formed
-
-                    Please keep the subject line 72 characters or under
-                    "
-                )
-                .into(),
+                HELP_MESSAGE.into(),
                 Code::SubjectLongerThan72Characters,
             )),
         );
@@ -194,14 +187,7 @@ mod tests {
         test_subject_longer_than_72_characters(
             &format!("{}\n", "x".repeat(73)),
             &Some(Problem::new(
-                indoc!(
-                    "
-                    Your commit is not well formed
-
-                    Please keep the subject line 72 characters or under
-                    "
-                )
-                .into(),
+                HELP_MESSAGE.into(),
                 Code::SubjectLongerThan72Characters,
             )),
         );
@@ -267,14 +253,7 @@ mod tests {
         test_subject_longer_than_72_characters(
             &format!("{}\n\n{}", "x".repeat(73), message),
             &Some(Problem::new(
-                indoc!(
-                    "
-                    Your commit is not well formed
-
-                    Please keep the subject line 72 characters or under
-                    "
-                )
-                .into(),
+                HELP_MESSAGE.into(),
                 Code::SubjectLongerThan72Characters,
             )),
         );

--- a/mit-commit-message-lints/src/lints/lib/subject_not_capitalized.rs
+++ b/mit-commit-message-lints/src/lints/lib/subject_not_capitalized.rs
@@ -6,7 +6,7 @@ pub(crate) const CONFIG: &str = "subject-line-not-capitalized";
 
 const HELP_MESSAGE: &str = indoc!(
     "
-    You forgot to capitalise the subject
+    Your commit message is missing a capital letter
 
     You can fix this by capitalising the first character in the subject
     "

--- a/mit-commit-message-lints/src/lints/lib/subject_not_seperate_from_body.rs
+++ b/mit-commit-message-lints/src/lints/lib/subject_not_seperate_from_body.rs
@@ -6,22 +6,15 @@ pub(crate) const CONFIG: &str = "subject-not-separated-from-body";
 
 const HELP_MESSAGE: &str = indoc!(
     "
-    Your commit is not well formed
+    Your commit message is missing a blank line between the subject and the body
 
     To fix this separate subject from body with a blank line
-
-    For example:
-
-    Aligns time sprondle
-
-    The time sprondle is drifting backwards in the current
-    configuration, this corrects that.
     "
 );
 
 const SIZE_OF_SUBJECT: usize = 1;
 
-fn has_subject_not_separate_from_body(commit_message: &CommitMessage) -> bool {
+fn has_problem(commit_message: &CommitMessage) -> bool {
     let line_count = commit_message.content_line_count();
 
     match line_count {
@@ -32,7 +25,7 @@ fn has_subject_not_separate_from_body(commit_message: &CommitMessage) -> bool {
 }
 
 pub(crate) fn lint(commit_message: &CommitMessage) -> Option<Problem> {
-    if has_subject_not_separate_from_body(commit_message) {
+    if has_problem(commit_message) {
         Some(Problem::new(
             HELP_MESSAGE.into(),
             Code::SubjectNotSeparateFromBody,
@@ -158,21 +151,7 @@ mod tests {
                 "
             ),
             &Some(Problem::new(
-                indoc!(
-                    "
-                    Your commit is not well formed
-
-                    To fix this separate subject from body with a blank line
-
-                    For example:
-
-                    Aligns time sprondle
-
-                    The time sprondle is drifting backwards in the current
-                    configuration, this corrects that.
-                    "
-                )
-                .into(),
+                HELP_MESSAGE.into(),
                 Code::SubjectNotSeparateFromBody,
             )),
         );
@@ -186,21 +165,7 @@ mod tests {
                 "
             ),
             &Some(Problem::new(
-                indoc!(
-                    "
-                    Your commit is not well formed
-
-                    To fix this separate subject from body with a blank line
-
-                    For example:
-
-                    Aligns time sprondle
-
-                    The time sprondle is drifting backwards in the current
-                    configuration, this corrects that.
-                    "
-                )
-                .into(),
+                HELP_MESSAGE.into(),
                 Code::SubjectNotSeparateFromBody,
             )),
         );

--- a/mit-commit-msg/tests/e2e_checks_if_there_are_no_duplicated_trailers.rs
+++ b/mit-commit-msg/tests/e2e_checks_if_there_are_no_duplicated_trailers.rs
@@ -43,10 +43,9 @@ fn duplicated_trailer() {
 
             ---
 
-            Your commit cannot have the same name duplicated in the \"Signed-off-by\" field
+            Your commit message has duplicated trailers
 
-            You can fix this by removing the duplicated field when you commit again
-
+            You can fix this by deleting the duplicated \"Signed-off-by\" field
             "
         ),
         false,

--- a/mit-commit-msg/tests/e2e_checks_if_there_is_a_jira_issue_key.rs
+++ b/mit-commit-msg/tests/e2e_checks_if_there_is_a_jira_issue_key.rs
@@ -75,7 +75,7 @@ fn explicitly_enabled() {
 
         ---
 
-        Your commit is missing a JIRA Issue Key
+        Your commit message is missing a JIRA Issue Key
 
         You can fix this by adding a key like `JRA-123` to the commit message
 

--- a/mit-commit-msg/tests/e2e_checks_if_there_is_a_pivotal_tracker_id.rs
+++ b/mit-commit-msg/tests/e2e_checks_if_there_is_a_pivotal_tracker_id.rs
@@ -74,7 +74,7 @@ fn enabled() {
 
         ---
 
-        Your commit is missing a Pivotal Tracker Id
+        Your commit message is missing a Pivotal Tracker Id
 
         You can fix this by adding the Id in one of the styles below to the commit message
         [Delivers #12345678]


### PR DESCRIPTION
The lint messages "feel" very different inbetween each lint. This makes
them feel similar.
