### PR TITLE
push out commit message from lints

### DIFF
--- a/git-mit-config/build.rs
+++ b/git-mit-config/build.rs
@@ -1,13 +1,14 @@
-use clap_generate::generators::{Bash, Elvish, Fish};
-
-use mit_commit_message_lints::lints::Lint;
 use std::env;
 use std::path::PathBuf;
 
-#[path = "src/cli.rs"]
-mod cli;
+use clap_generate::generators::{Bash, Elvish, Fish};
+
 use mit_build_tools::completion;
 use mit_build_tools::manpage;
+use mit_commit_message_lints::lints::Lint;
+
+#[path = "src/cli.rs"]
+mod cli;
 
 fn main() {
     let lint_names: Vec<_> = Lint::iterator()

--- a/git-mit-config/src/errors.rs
+++ b/git-mit-config/src/errors.rs
@@ -1,5 +1,6 @@
-use mit_commit_message_lints::{author, external, lints};
 use thiserror::Error;
+
+use mit_commit_message_lints::{author, external, lints};
 
 #[derive(Error, Debug)]
 pub enum GitMitConfigError {

--- a/git-mit-config/src/lints.rs
+++ b/git-mit-config/src/lints.rs
@@ -1,13 +1,16 @@
-use crate::errors::GitMitConfigError;
-use crate::errors::GitMitConfigError::LintNameNotGiven;
+use std::convert::TryInto;
+use std::path::PathBuf;
+
 use clap::ArgMatches;
+
 use mit_commit_message_lints::external;
 use mit_commit_message_lints::external::Vcs;
 use mit_commit_message_lints::lints::set_status;
 use mit_commit_message_lints::lints::Lint;
 use mit_commit_message_lints::lints::Lints;
-use std::convert::TryInto;
-use std::path::PathBuf;
+
+use crate::errors::GitMitConfigError;
+use crate::errors::GitMitConfigError::LintNameNotGiven;
 
 pub(crate) fn manage_lints(
     args: &ArgMatches,

--- a/git-mit-config/src/main.rs
+++ b/git-mit-config/src/main.rs
@@ -1,14 +1,14 @@
+use std::convert::TryInto;
 use std::env;
 
 use git2::{Config, Repository};
 
-use crate::errors::GitMitConfigError;
-use crate::lints::manage_lints;
-
-use crate::cli::app;
 use mit_commit_message_lints::lints::Lint;
 use mit_commit_message_lints::{author::entities::Authors, external::Git2};
-use std::convert::TryInto;
+
+use crate::cli::app;
+use crate::errors::GitMitConfigError;
+use crate::lints::manage_lints;
 
 fn main() -> Result<(), GitMitConfigError> {
     let lint_names: Vec<&str> = Lint::iterator()

--- a/git-mit-install/build.rs
+++ b/git-mit-install/build.rs
@@ -1,12 +1,13 @@
-use clap_generate::generators::{Bash, Elvish, Fish, Zsh};
-
 use std::env;
 use std::path::PathBuf;
 
-#[path = "src/cli.rs"]
-mod cli;
+use clap_generate::generators::{Bash, Elvish, Fish, Zsh};
+
 use mit_build_tools::completion;
 use mit_build_tools::manpage;
+
+#[path = "src/cli.rs"]
+mod cli;
 
 fn main() {
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());

--- a/git-mit-install/src/main.rs
+++ b/git-mit-install/src/main.rs
@@ -1,5 +1,8 @@
-mod cli;
 use std::{env, fs, io};
+
+use thiserror::Error;
+
+mod cli;
 
 fn main() -> Result<(), GitMitInstallError> {
     cli::app().get_matches();
@@ -23,7 +26,6 @@ fn main() -> Result<(), GitMitInstallError> {
 
     Ok(())
 }
-use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum GitMitInstallError {

--- a/git-mit-relates-to/build.rs
+++ b/git-mit-relates-to/build.rs
@@ -1,12 +1,13 @@
-use clap_generate::generators::{Bash, Elvish, Fish, Zsh};
-
 use std::env;
 use std::path::PathBuf;
 
-#[path = "src/cli.rs"]
-mod cli;
+use clap_generate::generators::{Bash, Elvish, Fish, Zsh};
+
 use mit_build_tools::completion;
 use mit_build_tools::manpage;
+
+#[path = "src/cli.rs"]
+mod cli;
 
 fn main() {
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());

--- a/git-mit-relates-to/src/errors.rs
+++ b/git-mit-relates-to/src/errors.rs
@@ -1,6 +1,8 @@
-use mit_commit_message_lints::{external, relates};
 use std::{io, num, string};
+
 use thiserror::Error;
+
+use mit_commit_message_lints::{external, relates};
 
 #[derive(Error, Debug)]
 pub enum GitRelatesTo {

--- a/git-mit-relates-to/src/main.rs
+++ b/git-mit-relates-to/src/main.rs
@@ -2,15 +2,15 @@ use std::{convert::TryFrom, env, time::Duration};
 
 use clap::ArgMatches;
 
-mod cli;
-mod errors;
-
 use mit_commit_message_lints::{
     external::Git2,
     relates::{entities::RelateTo, vcs::set_relates_to},
 };
 
 use crate::errors::GitRelatesTo;
+
+mod cli;
+mod errors;
 
 fn main() -> Result<(), errors::GitRelatesTo> {
     let matches = cli::app().get_matches();

--- a/git-mit/build.rs
+++ b/git-mit/build.rs
@@ -1,12 +1,13 @@
-use clap_generate::generators::{Bash, Elvish, Fish, Zsh};
-
 use std::env;
 use std::path::PathBuf;
 
-#[path = "src/cli.rs"]
-mod cli;
+use clap_generate::generators::{Bash, Elvish, Fish, Zsh};
+
 use mit_build_tools::completion;
 use mit_build_tools::manpage;
+
+#[path = "src/cli.rs"]
+mod cli;
 
 fn main() {
     let cargo_package_name = env!("CARGO_PKG_NAME");

--- a/git-mit/src/errors.rs
+++ b/git-mit/src/errors.rs
@@ -1,6 +1,8 @@
-use mit_commit_message_lints::{author, external};
 use std::string;
+
 use thiserror::Error;
+
+use mit_commit_message_lints::{author, external};
 
 #[derive(Error, Debug)]
 pub enum GitMitError {

--- a/mit-build-tools/src/completion/generate.rs
+++ b/mit-build-tools/src/completion/generate.rs
@@ -1,7 +1,8 @@
-use clap::App;
-use clap_generate::{generate_to, Generator};
 use std::fs;
 use std::path::PathBuf;
+
+use clap::App;
+use clap_generate::{generate_to, Generator};
 
 pub fn generate<T>(app: &App, dir: &PathBuf)
 where

--- a/mit-build-tools/src/manpage/formatters.rs
+++ b/mit-build-tools/src/manpage/formatters.rs
@@ -1,5 +1,4 @@
 use tinytemplate::error::Error;
-
 use tinytemplate::format_unescaped;
 
 /// Format a string as uppercase

--- a/mit-build-tools/src/manpage/generate.rs
+++ b/mit-build-tools/src/manpage/generate.rs
@@ -1,4 +1,13 @@
+use std::fs;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+use clap::App;
 use serde::Serialize;
+use tinytemplate::TinyTemplate;
+
+use crate::manpage::formatters;
 
 #[derive(Serialize)]
 struct Context {
@@ -16,15 +25,6 @@ struct Context {
     after_help: String,
     before_help: String,
 }
-
-use crate::manpage::formatters;
-use clap::App;
-
-use std::fs;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-use tinytemplate::TinyTemplate;
 
 pub fn generate(app: &App, out_dir: &PathBuf, md_template: &str) {
     let mut tt = TinyTemplate::new();

--- a/mit-build-tools/src/manpage/mod.rs
+++ b/mit-build-tools/src/manpage/mod.rs
@@ -1,5 +1,5 @@
-mod generate;
-
 pub use generate::generate;
+
+mod generate;
 
 mod formatters;

--- a/mit-commit-message-lints/src/author/mod.rs
+++ b/mit-commit-message-lints/src/author/mod.rs
@@ -1,6 +1,6 @@
+pub use serialize::Error as YamlError;
+pub use vcs::Error as VcsError;
+
 pub mod entities;
 pub mod serialize;
 pub mod vcs;
-
-pub use serialize::Error as YamlError;
-pub use vcs::Error as VcsError;

--- a/mit-commit-message-lints/src/author/serialize.rs
+++ b/mit-commit-message-lints/src/author/serialize.rs
@@ -1,6 +1,8 @@
-use crate::author::entities::Authors;
 use std::convert::TryFrom;
+
 use thiserror::Error;
+
+use crate::author::entities::Authors;
 
 impl TryFrom<&str> for Authors {
     type Error = Error;
@@ -25,12 +27,14 @@ impl TryFrom<Authors> for String {
 
 #[cfg(test)]
 mod tests {
-    use crate::author::entities::{Author, Authors};
-    use indoc::indoc;
-    use pretty_assertions::assert_eq;
     use std::collections::BTreeMap;
     use std::convert::TryFrom;
     use std::convert::TryInto;
+
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+
+    use crate::author::entities::{Author, Authors};
 
     #[test]
     fn must_be_valid_yaml() {

--- a/mit-commit-message-lints/src/author/vcs.rs
+++ b/mit-commit-message-lints/src/author/vcs.rs
@@ -1,3 +1,4 @@
+use std::{convert::TryInto, time::SystemTimeError};
 use std::{
     num,
     ops::Add,
@@ -7,9 +8,9 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use crate::{author::entities::Author, external, external::Vcs};
-use std::{convert::TryInto, time::SystemTimeError};
 use thiserror::Error;
+
+use crate::{author::entities::Author, external, external::Vcs};
 
 const CONFIG_KEY_EXPIRES: &str = "mit.author.expires";
 

--- a/mit-commit-message-lints/src/external/config.rs
+++ b/mit-commit-message-lints/src/external/config.rs
@@ -1,7 +1,9 @@
-use crate::external::Error;
-use git2::Repository;
 use std::fs;
 use std::path::PathBuf;
+
+use git2::Repository;
+
+use crate::external::Error;
 
 /// Find and read the correct toml config
 ///

--- a/mit-commit-message-lints/src/external/git2.rs
+++ b/mit-commit-message-lints/src/external/git2.rs
@@ -1,7 +1,9 @@
-use crate::external::{Error, Vcs};
+use std::path::PathBuf;
+
 use git2::{Config, Repository};
 use serde::export::TryFrom;
-use std::path::PathBuf;
+
+use crate::external::{Error, Vcs};
 
 pub struct Git2 {
     config_snapshot: git2::Config,

--- a/mit-commit-message-lints/src/external/in_memory.rs
+++ b/mit-commit-message-lints/src/external/in_memory.rs
@@ -1,5 +1,6 @@
-use crate::external::{Error, Vcs};
 use std::{collections::BTreeMap, string::String};
+
+use crate::external::{Error, Vcs};
 
 pub struct InMemory<'a> {
     store: &'a mut BTreeMap<String, String>,

--- a/mit-commit-message-lints/src/external/mod.rs
+++ b/mit-commit-message-lints/src/external/mod.rs
@@ -1,10 +1,10 @@
-mod config;
-mod git2;
-mod in_memory;
-mod vcs;
-
 pub use self::config::read_toml;
 pub use self::git2::Git2;
 pub use self::in_memory::InMemory;
 pub use self::vcs::Error;
 pub use self::vcs::Vcs;
+
+mod config;
+mod git2;
+mod in_memory;
+mod vcs;

--- a/mit-commit-message-lints/src/lints/cmd/lint.rs
+++ b/mit-commit-message-lints/src/lints/cmd/lint.rs
@@ -1,4 +1,5 @@
-use crate::lints::lib::{CommitMessage, Lints, Problem};
+use crate::lints::lib::{Lints, Problem};
+use mit_commit::CommitMessage;
 
 #[must_use]
 pub fn lint(commit_message: &CommitMessage, lints: Lints) -> Vec<Problem> {

--- a/mit-commit-message-lints/src/lints/cmd/mod.rs
+++ b/mit-commit-message-lints/src/lints/cmd/mod.rs
@@ -1,6 +1,6 @@
-mod lint;
-mod set_status;
-
 pub use lint::lint;
 pub use set_status::set_status;
 pub use set_status::Error as SetStatusError;
+
+mod lint;
+mod set_status;

--- a/mit-commit-message-lints/src/lints/cmd/set_status.rs
+++ b/mit-commit-message-lints/src/lints/cmd/set_status.rs
@@ -1,7 +1,8 @@
+use thiserror::Error;
+
 use crate::external;
 use crate::external::Vcs;
 use crate::lints::lib::Lints;
-use thiserror::Error;
 
 /// # Errors
 ///
@@ -16,11 +17,13 @@ pub fn set_status(lints: Lints, vcs: &mut dyn Vcs, status: bool) -> Result<(), E
 
 #[cfg(test)]
 mod tests_can_enable_lints_via_a_command {
+    use std::collections::{BTreeMap, BTreeSet};
+
+    use pretty_assertions::assert_eq;
+
     use crate::external::InMemory;
     use crate::lints::cmd::set_status::set_status;
     use crate::lints::lib::{Lint, Lints};
-    use pretty_assertions::assert_eq;
-    use std::collections::{BTreeMap, BTreeSet};
 
     #[test]
     fn we_can_enable_lints() {

--- a/mit-commit-message-lints/src/lints/lib/commit_message.rs
+++ b/mit-commit-message-lints/src/lints/lib/commit_message.rs
@@ -1,4 +1,3 @@
-use regex::{Regex, RegexBuilder};
 use std::{
     convert::TryFrom,
     fmt::Display,
@@ -8,6 +7,9 @@ use std::{
     path::PathBuf,
     str::{FromStr, Lines},
 };
+
+use mit_commit::CommitMessage as NgCommitMessage;
+use regex::{Regex, RegexBuilder};
 use thiserror::Error;
 
 use super::Trailer;
@@ -205,8 +207,6 @@ impl Display for CommitMessage {
     }
 }
 
-use mit_commit::CommitMessage as NgCommitMessage;
-
 impl From<CommitMessage> for NgCommitMessage {
     fn from(old: CommitMessage) -> Self {
         NgCommitMessage::from(format!("{}", old))
@@ -227,8 +227,14 @@ impl From<NgCommitMessage> for CommitMessage {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
+    use indoc::indoc;
     use mit_commit::CommitMessage as NgCommitMessage;
     use pretty_assertions::assert_eq;
+    use regex::Regex;
+
+    use super::{CommitMessage, Trailer};
 
     #[test]
     fn can_convert_from_a_old_commit_to_a_new_one() {
@@ -281,13 +287,6 @@ mod tests {
             )
         );
     }
-
-    use regex::Regex;
-    use std::str::FromStr;
-
-    use indoc::indoc;
-
-    use super::{CommitMessage, Trailer};
 
     #[test]
     fn with_trailers() {
@@ -829,6 +828,7 @@ mod tests {
             commit.get_body()
         );
     }
+
     #[test]
     fn body_still_retrieved_without_gutter() {
         let commit = CommitMessage::new(

--- a/mit-commit-message-lints/src/lints/lib/duplicate_trailers.rs
+++ b/mit-commit-message-lints/src/lints/lib/duplicate_trailers.rs
@@ -1,11 +1,11 @@
 use std::collections::BTreeMap;
 use std::ops::Add;
 
-use mit_commit::CommitMessage as NgCommitMessage;
+use mit_commit::CommitMessage;
 use mit_commit::Trailer as NgTrailer;
 
 use crate::lints::lib::problem::Code;
-use crate::lints::lib::{CommitMessage, Problem};
+use crate::lints::lib::Problem;
 
 pub(crate) const CONFIG: &str = "duplicated-trailers";
 
@@ -13,7 +13,7 @@ const TRAILERS_TO_CHECK_FOR_DUPLICATES: [&str; 2] = ["Signed-off-by", "Co-author
 const FIELD_SINGULAR: &str = "field";
 const FIELD_PLURAL: &str = "fields";
 
-fn get_duplicated_trailers(commit_message: &NgCommitMessage) -> Vec<String> {
+fn get_duplicated_trailers(commit_message: &CommitMessage) -> Vec<String> {
     commit_message
         .get_trailers()
         .iter()
@@ -42,9 +42,7 @@ fn get_duplicated_trailers(commit_message: &NgCommitMessage) -> Vec<String> {
         .collect::<Vec<_>>()
 }
 
-pub(crate) fn lint(commit_message: &CommitMessage) -> Option<Problem> {
-    let commit = &NgCommitMessage::from(format!("{}", commit_message));
-
+pub(crate) fn lint(commit: &CommitMessage) -> Option<Problem> {
     let duplicated_trailers = get_duplicated_trailers(commit);
     if duplicated_trailers.is_empty() {
         None
@@ -75,6 +73,7 @@ mod tests_has_duplicated_trailers {
     use pretty_assertions::assert_eq;
 
     use super::*;
+    use mit_commit::CommitMessage;
 
     #[test]
     fn commit_without_trailers() {
@@ -211,7 +210,7 @@ mod tests_has_duplicated_trailers {
     }
 
     fn test_lint_duplicated_trailers(message: String, expected: &Option<Problem>) {
-        let actual = &lint(&CommitMessage::new(message));
+        let actual = &lint(&CommitMessage::from(message));
         assert_eq!(
             actual, expected,
             "Expected {:?}, found {:?}",

--- a/mit-commit-message-lints/src/lints/lib/duplicate_trailers.rs
+++ b/mit-commit-message-lints/src/lints/lib/duplicate_trailers.rs
@@ -1,9 +1,11 @@
-use crate::lints::lib::problem::Code;
-use crate::lints::lib::{CommitMessage, Problem};
-use mit_commit::CommitMessage as NgCommitMessage;
-use mit_commit::Trailer as NgTrailer;
 use std::collections::BTreeMap;
 use std::ops::Add;
+
+use mit_commit::CommitMessage as NgCommitMessage;
+use mit_commit::Trailer as NgTrailer;
+
+use crate::lints::lib::problem::Code;
+use crate::lints::lib::{CommitMessage, Problem};
 
 pub(crate) const CONFIG: &str = "duplicated-trailers";
 
@@ -88,6 +90,7 @@ mod tests_has_duplicated_trailers {
             &None,
         );
     }
+
     #[test]
     fn two_duplicates() {
         test_lint_duplicated_trailers(
@@ -109,6 +112,7 @@ mod tests_has_duplicated_trailers {
             )),
         );
     }
+
     #[test]
     fn signed_off_by() {
         test_lint_duplicated_trailers(
@@ -128,6 +132,7 @@ mod tests_has_duplicated_trailers {
             )),
         );
     }
+
     #[test]
     fn co_authored_by() {
         test_lint_duplicated_trailers(
@@ -140,8 +145,7 @@ mod tests_has_duplicated_trailers {
                 Co-authored-by: Billie Thompson <email@example.com>
                 Co-authored-by: Billie Thompson <email@example.com>
                 "
-            )
-            .into(),
+            ).into(),
             &Some(Problem::new(
                 "Your commit message has duplicated trailers\n\nYou can fix this by deleting the duplicated \"Co-authored-by\" field".into(),
                 Code::DuplicatedTrailers,
@@ -183,11 +187,11 @@ mod tests_has_duplicated_trailers {
                  You can fix this by deleting the duplicated \"Signed-off-by\", \"Co-authored-by\" fields
                 +
                 "
-            )
-            .into(),
+            ).into(),
             &None,
         );
     }
+
     #[test]
     fn other_trailers() {
         test_lint_duplicated_trailers(

--- a/mit-commit-message-lints/src/lints/lib/lint.rs
+++ b/mit-commit-message-lints/src/lints/lib/lint.rs
@@ -1,8 +1,10 @@
+use std::convert::TryInto;
+
+use thiserror::Error;
+
 use crate::lints::lib;
 use crate::lints::lib::problem::Problem;
 use crate::lints::lib::{CommitMessage, Lints};
-use std::convert::TryInto;
-use thiserror::Error;
 
 /// The lints that are supported
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Hash, Ord, PartialOrd)]

--- a/mit-commit-message-lints/src/lints/lib/lint.rs
+++ b/mit-commit-message-lints/src/lints/lib/lint.rs
@@ -1,10 +1,11 @@
 use std::convert::TryInto;
 
+use mit_commit::CommitMessage;
 use thiserror::Error;
 
 use crate::lints::lib;
 use crate::lints::lib::problem::Problem;
-use crate::lints::lib::{CommitMessage, Lints};
+use crate::lints::lib::Lints;
 
 /// The lints that are supported
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Hash, Ord, PartialOrd)]

--- a/mit-commit-message-lints/src/lints/lib/lints.rs
+++ b/mit-commit-message-lints/src/lints/lib/lints.rs
@@ -1,12 +1,14 @@
-use crate::external;
-use crate::external::Vcs;
-use crate::lints::lib::{lint, Lint};
 use std::borrow::Borrow;
 use std::collections::{BTreeMap, BTreeSet};
 use std::convert::{TryFrom, TryInto};
 use std::iter::FromIterator;
 use std::vec::IntoIter;
+
 use thiserror::Error;
+
+use crate::external;
+use crate::external::Vcs;
+use crate::lints::lib::{lint, Lint};
 
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct Lints {
@@ -138,20 +140,18 @@ fn get_config_or_default(
 
 #[cfg(test)]
 mod tests {
-    use crate::lints::lib::lints::{Error, Lints};
-    use indoc::indoc;
-
-    use crate::lints::Lint::{JiraIssueKeyMissing, PivotalTrackerIdMissing};
-    use pretty_assertions::assert_eq;
-
     use std::collections::{BTreeMap, BTreeSet};
+    use std::convert::TryInto;
 
-    use crate::{external::InMemory, lints::Lint::DuplicatedTrailers};
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
 
     use crate::lints::lib::lint::Lint::{
         GitHubIdMissing, SubjectLongerThan72Characters, SubjectNotSeparateFromBody,
     };
-    use std::convert::TryInto;
+    use crate::lints::lib::lints::{Error, Lints};
+    use crate::lints::Lint::{JiraIssueKeyMissing, PivotalTrackerIdMissing};
+    use crate::{external::InMemory, lints::Lint::DuplicatedTrailers};
 
     #[test]
     fn it_returns_an_error_if_one_of_the_names_is_wrong() {
@@ -220,6 +220,7 @@ mod tests {
 
         assert_eq!(expected, actual);
     }
+
     #[test]
     fn try_from_toml_defaults() {
         let mut store = BTreeMap::new();
@@ -477,6 +478,7 @@ mod tests {
             expected, actual
         )
     }
+
     #[test]
     fn when_merging_overlapping_does_not_lead_to_duplication() {
         let mut set_a_lints = BTreeSet::new();
@@ -502,6 +504,7 @@ mod tests {
             expected, actual
         )
     }
+
     #[test]
     fn we_can_subtract_lints_from_the_lint_list() {
         let mut set_a_lints = BTreeSet::new();

--- a/mit-commit-message-lints/src/lints/lib/missing_github_id.rs
+++ b/mit-commit-message-lints/src/lints/lib/missing_github_id.rs
@@ -1,9 +1,9 @@
 use indoc::indoc;
-use mit_commit::CommitMessage as NgCommitMessage;
+use mit_commit::CommitMessage;
 use regex::Regex;
 
 use crate::lints::lib::problem::Code;
-use crate::lints::lib::{CommitMessage, Problem};
+use crate::lints::lib::Problem;
 
 pub(crate) const CONFIG: &str = "github-id-missing";
 
@@ -23,8 +23,7 @@ const HELP_MESSAGE: &str = indoc!(
     "
 );
 
-pub(crate) fn lint(commit_message: &CommitMessage) -> Option<Problem> {
-    let mit_commit: NgCommitMessage = commit_message.into();
+pub(crate) fn lint(mit_commit: &CommitMessage) -> Option<Problem> {
     let re = Regex::new(r"(?m)(^| )([a-zA-Z0-9_-]{3,39}/[a-zA-Z0-9-]+#|GH-|#)[0-9]+( |$)").unwrap();
     if mit_commit.matches_pattern(&re) {
         None
@@ -295,7 +294,7 @@ mod tests_has_missing_github_id {
     }
 
     fn test_has_missing_github_id(message: &str, expected: &Option<Problem>) {
-        let actual = &lint(&CommitMessage::new(message.into()));
+        let actual = &lint(&CommitMessage::from(message));
         assert_eq!(
             actual, expected,
             "Message {:?} should have returned {:?}, found {:?}",

--- a/mit-commit-message-lints/src/lints/lib/missing_jira_issue_key.rs
+++ b/mit-commit-message-lints/src/lints/lib/missing_jira_issue_key.rs
@@ -1,8 +1,9 @@
 use indoc::indoc;
+use mit_commit::CommitMessage;
 use regex::Regex;
 
 use crate::lints::lib::problem::Code;
-use crate::lints::lib::{CommitMessage, Problem};
+use crate::lints::lib::Problem;
 
 pub(crate) const CONFIG: &str = "jira-issue-key-missing";
 
@@ -131,7 +132,7 @@ mod tests_has_missing_jira_issue_key {
     }
 
     fn test_has_missing_jira_issue_key(message: &str, expected: &Option<Problem>) {
-        let actual = &lint(&CommitMessage::new(message.into()));
+        let actual = &lint(&CommitMessage::from(message));
         assert_eq!(
             actual, expected,
             "Message {:?} should have returned {:?}, found {:?}",

--- a/mit-commit-message-lints/src/lints/lib/missing_jira_issue_key.rs
+++ b/mit-commit-message-lints/src/lints/lib/missing_jira_issue_key.rs
@@ -1,8 +1,8 @@
+use indoc::indoc;
 use regex::Regex;
 
 use crate::lints::lib::problem::Code;
 use crate::lints::lib::{CommitMessage, Problem};
-use indoc::indoc;
 
 pub(crate) const CONFIG: &str = "jira-issue-key-missing";
 

--- a/mit-commit-message-lints/src/lints/lib/missing_pivotal_tracker_id.rs
+++ b/mit-commit-message-lints/src/lints/lib/missing_pivotal_tracker_id.rs
@@ -1,9 +1,9 @@
+use indoc::indoc;
+use mit_commit::CommitMessage as NgCommitMessage;
 use regex::Regex;
 
 use crate::lints::lib::problem::Code;
 use crate::lints::lib::{CommitMessage, Problem};
-use indoc::indoc;
-use mit_commit::CommitMessage as NgCommitMessage;
 
 pub(crate) const CONFIG: &str = "pivotal-tracker-id-missing";
 
@@ -45,10 +45,10 @@ pub(crate) fn lint(commit_message: &CommitMessage) -> Option<Problem> {
 mod tests_has_missing_pivotal_tracker_id {
     #![allow(clippy::wildcard_imports)]
 
+    use indoc::indoc;
     use pretty_assertions::assert_eq;
 
     use crate::lints::CommitMessage;
-    use indoc::indoc;
 
     use super::*;
 

--- a/mit-commit-message-lints/src/lints/lib/missing_pivotal_tracker_id.rs
+++ b/mit-commit-message-lints/src/lints/lib/missing_pivotal_tracker_id.rs
@@ -1,9 +1,9 @@
 use indoc::indoc;
-use mit_commit::CommitMessage as NgCommitMessage;
+use mit_commit::CommitMessage;
 use regex::Regex;
 
 use crate::lints::lib::problem::Code;
-use crate::lints::lib::{CommitMessage, Problem};
+use crate::lints::lib::Problem;
 
 pub(crate) const CONFIG: &str = "pivotal-tracker-id-missing";
 
@@ -22,8 +22,7 @@ const HELP_MESSAGE: &str = indoc!(
     "
 );
 
-pub(crate) fn lint(commit_message: &CommitMessage) -> Option<Problem> {
-    let commit: NgCommitMessage = commit_message.into();
+pub(crate) fn lint(commit: &CommitMessage) -> Option<Problem> {
     let re = Regex::new(
         r"(?i)\[(((finish|fix)(ed|es)?|complete[ds]?|deliver(s|ed)?) )?#\d+([, ]#\d+)*]",
     )
@@ -45,8 +44,6 @@ mod tests_has_missing_pivotal_tracker_id {
     use indoc::indoc;
     use pretty_assertions::assert_eq;
 
-    use crate::lints::CommitMessage;
-
     use super::*;
 
     #[test]
@@ -67,7 +64,7 @@ mod tests_has_missing_pivotal_tracker_id {
     }
 
     fn test_has_missing_pivotal_tracker_id(message: &str, expected: &Option<Problem>) {
-        let actual = &lint(&CommitMessage::new(message.into()));
+        let actual = &lint(&CommitMessage::from(message));
         assert_eq!(
             actual, expected,
             "Message {:?} should have returned {:?}, found {:?}",

--- a/mit-commit-message-lints/src/lints/lib/missing_pivotal_tracker_id.rs
+++ b/mit-commit-message-lints/src/lints/lib/missing_pivotal_tracker_id.rs
@@ -22,12 +22,13 @@ const HELP_MESSAGE: &str = indoc!(
     "
 );
 
-pub(crate) fn nglint(commit_message: &NgCommitMessage) -> Option<Problem> {
+pub(crate) fn lint(commit_message: &CommitMessage) -> Option<Problem> {
+    let commit: NgCommitMessage = commit_message.into();
     let re = Regex::new(
         r"(?i)\[(((finish|fix)(ed|es)?|complete[ds]?|deliver(s|ed)?) )?#\d+([, ]#\d+)*]",
     )
     .unwrap();
-    if commit_message.matches_pattern(&re) {
+    if commit.matches_pattern(&re) {
         None
     } else {
         Some(Problem::new(
@@ -35,10 +36,6 @@ pub(crate) fn nglint(commit_message: &NgCommitMessage) -> Option<Problem> {
             Code::PivotalTrackerIdMissing,
         ))
     }
-}
-
-pub(crate) fn lint(commit_message: &CommitMessage) -> Option<Problem> {
-    nglint(&commit_message.into())
 }
 
 #[cfg(test)]

--- a/mit-commit-message-lints/src/lints/lib/mod.rs
+++ b/mit-commit-message-lints/src/lints/lib/mod.rs
@@ -1,12 +1,3 @@
-mod commit_message;
-mod error;
-mod lint;
-mod lints;
-mod subject_longer_than_72_characters;
-mod subject_not_capitalized;
-mod subject_not_seperate_from_body;
-mod trailer;
-
 pub use commit_message::CommitMessage;
 pub use commit_message::Error as CommitMessageError;
 pub use error::Error;
@@ -16,6 +7,15 @@ pub use lints::Error as LintsError;
 pub use lints::Lints;
 pub use problem::{Code, Problem};
 pub use trailer::Trailer;
+
+mod commit_message;
+mod error;
+mod lint;
+mod lints;
+mod subject_longer_than_72_characters;
+mod subject_not_capitalized;
+mod subject_not_seperate_from_body;
+mod trailer;
 
 mod duplicate_trailers;
 mod missing_github_id;

--- a/mit-commit-message-lints/src/lints/lib/subject_longer_than_72_characters.rs
+++ b/mit-commit-message-lints/src/lints/lib/subject_longer_than_72_characters.rs
@@ -1,7 +1,8 @@
-use crate::lints::lib::problem::Code;
-use crate::lints::lib::{CommitMessage, Problem};
 use indoc::indoc;
 use mit_commit::CommitMessage as NgCommitMessage;
+
+use crate::lints::lib::problem::Code;
+use crate::lints::lib::{CommitMessage, Problem};
 
 pub(crate) const CONFIG: &str = "subject-longer-than-72-characters";
 

--- a/mit-commit-message-lints/src/lints/lib/subject_longer_than_72_characters.rs
+++ b/mit-commit-message-lints/src/lints/lib/subject_longer_than_72_characters.rs
@@ -1,8 +1,8 @@
 use indoc::indoc;
-use mit_commit::CommitMessage as NgCommitMessage;
+use mit_commit::CommitMessage;
 
 use crate::lints::lib::problem::Code;
-use crate::lints::lib::{CommitMessage, Problem};
+use crate::lints::lib::Problem;
 
 pub(crate) const CONFIG: &str = "subject-longer-than-72-characters";
 
@@ -14,8 +14,7 @@ const HELP_MESSAGE: &str = indoc!(
     "
 );
 
-pub(crate) fn lint(commit_message: &CommitMessage) -> Option<Problem> {
-    let commit: &NgCommitMessage = &commit_message.into();
+pub(crate) fn lint(commit: &CommitMessage) -> Option<Problem> {
     if commit.get_subject().len() > 72 {
         Some(Problem::new(
             HELP_MESSAGE.into(),
@@ -321,7 +320,7 @@ mod tests {
     }
 
     fn test_subject_longer_than_72_characters(message: &str, expected: &Option<Problem>) {
-        let actual = &lint(&CommitMessage::new(message.into()));
+        let actual = &lint(&CommitMessage::from(message));
         assert_eq!(
             actual, expected,
             "Message {:?} should have returned {:?}, found {:?}",

--- a/mit-commit-message-lints/src/lints/lib/subject_longer_than_72_characters.rs
+++ b/mit-commit-message-lints/src/lints/lib/subject_longer_than_72_characters.rs
@@ -15,7 +15,7 @@ const HELP_MESSAGE: &str = indoc!(
 );
 
 pub(crate) fn lint(commit_message: &CommitMessage) -> Option<Problem> {
-    let commit: &NgCommitMessage = &format!("{}", commit_message).into();
+    let commit: &NgCommitMessage = &commit_message.into();
     if commit.get_subject().len() > 72 {
         Some(Problem::new(
             HELP_MESSAGE.into(),

--- a/mit-commit-message-lints/src/lints/lib/subject_not_capitalized.rs
+++ b/mit-commit-message-lints/src/lints/lib/subject_not_capitalized.rs
@@ -1,4 +1,5 @@
 use indoc::indoc;
+use mit_commit::CommitMessage as NgCommitMessage;
 
 use crate::lints::lib::problem::Code;
 use crate::lints::lib::{CommitMessage, Problem};
@@ -13,16 +14,16 @@ const HELP_MESSAGE: &str = indoc!(
     "
 );
 
-fn has_problem(commit_message: &CommitMessage) -> bool {
+fn has_problem(commit_message: &NgCommitMessage) -> bool {
     if let Some(character) = commit_message.get_subject().chars().next() {
-        return character.to_string() != character.to_uppercase().to_string();
+        character.to_string() != character.to_uppercase().to_string()
+    } else {
+        false
     }
-
-    false
 }
 
 pub(crate) fn lint(commit_message: &CommitMessage) -> Option<Problem> {
-    if has_problem(commit_message) {
+    if has_problem(&commit_message.into()) {
         Some(Problem::new(
             HELP_MESSAGE.into(),
             Code::SubjectLintNotCapitalized,

--- a/mit-commit-message-lints/src/lints/lib/subject_not_capitalized.rs
+++ b/mit-commit-message-lints/src/lints/lib/subject_not_capitalized.rs
@@ -1,8 +1,8 @@
 use indoc::indoc;
-use mit_commit::CommitMessage as NgCommitMessage;
+use mit_commit::CommitMessage;
 
 use crate::lints::lib::problem::Code;
-use crate::lints::lib::{CommitMessage, Problem};
+use crate::lints::lib::Problem;
 
 pub(crate) const CONFIG: &str = "subject-line-not-capitalized";
 
@@ -14,7 +14,7 @@ const HELP_MESSAGE: &str = indoc!(
     "
 );
 
-fn has_problem(commit_message: &NgCommitMessage) -> bool {
+fn has_problem(commit_message: &CommitMessage) -> bool {
     if let Some(character) = commit_message.get_subject().chars().next() {
         character.to_string() != character.to_uppercase().to_string()
     } else {
@@ -23,7 +23,7 @@ fn has_problem(commit_message: &NgCommitMessage) -> bool {
 }
 
 pub(crate) fn lint(commit_message: &CommitMessage) -> Option<Problem> {
-    if has_problem(&commit_message.into()) {
+    if has_problem(&commit_message) {
         Some(Problem::new(
             HELP_MESSAGE.into(),
             Code::SubjectLintNotCapitalized,
@@ -82,7 +82,7 @@ mod tests {
     }
 
     fn run_test(message: &str, expected: &Option<Problem>) {
-        let actual = &lint(&CommitMessage::new(message.into()));
+        let actual = &lint(&CommitMessage::from(message));
         assert_eq!(
             actual, expected,
             "Message {:?} should have returned {:?}, found {:?}",

--- a/mit-commit-message-lints/src/lints/lib/subject_not_capitalized.rs
+++ b/mit-commit-message-lints/src/lints/lib/subject_not_capitalized.rs
@@ -1,6 +1,7 @@
+use indoc::indoc;
+
 use crate::lints::lib::problem::Code;
 use crate::lints::lib::{CommitMessage, Problem};
-use indoc::indoc;
 
 pub(crate) const CONFIG: &str = "subject-line-not-capitalized";
 

--- a/mit-commit-message-lints/src/lints/lib/subject_not_seperate_from_body.rs
+++ b/mit-commit-message-lints/src/lints/lib/subject_not_seperate_from_body.rs
@@ -1,8 +1,8 @@
 use indoc::indoc;
+use mit_commit::CommitMessage;
 
 use crate::lints::lib::problem::Code;
-use crate::lints::lib::{CommitMessage, Problem};
-use mit_commit::CommitMessage as NgCommitMessage;
+use crate::lints::lib::Problem;
 
 pub(crate) const CONFIG: &str = "subject-not-separated-from-body";
 
@@ -14,7 +14,7 @@ const HELP_MESSAGE: &str = indoc!(
     "
 );
 
-fn has_problem(commit_message: &NgCommitMessage) -> bool {
+fn has_problem(commit_message: &CommitMessage) -> bool {
     commit_message
         .get_subject()
         .chars()
@@ -22,7 +22,7 @@ fn has_problem(commit_message: &NgCommitMessage) -> bool {
 }
 
 pub(crate) fn lint(commit_message: &CommitMessage) -> Option<Problem> {
-    if has_problem(&commit_message.into()) {
+    if has_problem(&commit_message) {
         Some(Problem::new(
             HELP_MESSAGE.into(),
             Code::SubjectNotSeparateFromBody,
@@ -169,7 +169,7 @@ mod tests {
     }
 
     fn test_subject_not_seperate_from_body(message: &str, expected: &Option<Problem>) {
-        let actual = &lint(&CommitMessage::new(message.into()));
+        let actual = &lint(&CommitMessage::from(message));
         assert_eq!(
             actual, expected,
             "Message {:?} should have returned {:?}, found {:?}",

--- a/mit-commit-message-lints/src/lints/lib/subject_not_seperate_from_body.rs
+++ b/mit-commit-message-lints/src/lints/lib/subject_not_seperate_from_body.rs
@@ -2,6 +2,7 @@ use indoc::indoc;
 
 use crate::lints::lib::problem::Code;
 use crate::lints::lib::{CommitMessage, Problem};
+use mit_commit::CommitMessage as NgCommitMessage;
 
 pub(crate) const CONFIG: &str = "subject-not-separated-from-body";
 
@@ -13,20 +14,15 @@ const HELP_MESSAGE: &str = indoc!(
     "
 );
 
-const SIZE_OF_SUBJECT: usize = 1;
-
-fn has_problem(commit_message: &CommitMessage) -> bool {
-    let line_count = commit_message.content_line_count();
-
-    match line_count {
-        1 => false,
-        2 => true,
-        _ => commit_message.get_body().lines().count() + SIZE_OF_SUBJECT == line_count,
-    }
+fn has_problem(commit_message: &NgCommitMessage) -> bool {
+    commit_message
+        .get_subject()
+        .chars()
+        .any(|char| '\n' == char)
 }
 
 pub(crate) fn lint(commit_message: &CommitMessage) -> Option<Problem> {
-    if has_problem(commit_message) {
+    if has_problem(&commit_message.into()) {
         Some(Problem::new(
             HELP_MESSAGE.into(),
             Code::SubjectNotSeparateFromBody,

--- a/mit-commit-message-lints/src/lints/lib/subject_not_seperate_from_body.rs
+++ b/mit-commit-message-lints/src/lints/lib/subject_not_seperate_from_body.rs
@@ -1,6 +1,7 @@
+use indoc::indoc;
+
 use crate::lints::lib::problem::Code;
 use crate::lints::lib::{CommitMessage, Problem};
-use indoc::indoc;
 
 pub(crate) const CONFIG: &str = "subject-not-separated-from-body";
 

--- a/mit-commit-message-lints/src/lints/lib/trailer.rs
+++ b/mit-commit-message-lints/src/lints/lib/trailer.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use std::str::FromStr;
+
 use thiserror::Error;
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]

--- a/mit-commit-message-lints/src/lints/mod.rs
+++ b/mit-commit-message-lints/src/lints/mod.rs
@@ -1,6 +1,3 @@
-pub mod cmd;
-pub mod lib;
-
 pub use cmd::lint;
 pub use cmd::set_status;
 pub use cmd::SetStatusError;
@@ -12,3 +9,6 @@ pub use lib::LintError;
 pub use lib::Lints;
 pub use lib::LintsError;
 pub use lib::Problem;
+
+pub mod cmd;
+pub mod lib;

--- a/mit-commit-message-lints/src/relates/mod.rs
+++ b/mit-commit-message-lints/src/relates/mod.rs
@@ -1,4 +1,4 @@
+pub use vcs::Error as VcsError;
+
 pub mod entities;
 pub mod vcs;
-
-pub use vcs::Error as VcsError;

--- a/mit-commit-message-lints/src/relates/vcs.rs
+++ b/mit-commit-message-lints/src/relates/vcs.rs
@@ -1,3 +1,4 @@
+use std::{convert::TryInto, time::SystemTimeError};
 use std::{
     num,
     ops::Add,
@@ -7,11 +8,12 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use super::entities::RelateTo;
+use thiserror::Error;
+
 use crate::external;
 use crate::external::Vcs;
-use std::{convert::TryInto, time::SystemTimeError};
-use thiserror::Error;
+
+use super::entities::RelateTo;
 
 const CONFIG_KEY_EXPIRES: &str = "mit.relate.expires";
 

--- a/mit-commit-msg/build.rs
+++ b/mit-commit-msg/build.rs
@@ -1,12 +1,13 @@
-use clap_generate::generators::{Bash, Elvish, Fish, Zsh};
-
 use std::env;
 use std::path::PathBuf;
 
-#[path = "src/cli.rs"]
-mod cli;
+use clap_generate::generators::{Bash, Elvish, Fish, Zsh};
+
 use mit_build_tools::completion;
 use mit_build_tools::manpage;
+
+#[path = "src/cli.rs"]
+mod cli;
 
 fn main() {
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());

--- a/mit-commit-msg/src/errors.rs
+++ b/mit-commit-msg/src/errors.rs
@@ -1,6 +1,7 @@
+use thiserror::Error;
+
 use mit_commit_message_lints::external;
 use mit_commit_message_lints::lints::{CommitMessageError, LintsError};
-use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub(crate) enum MitCommitMsgError {

--- a/mit-commit-msg/src/main.rs
+++ b/mit-commit-msg/src/main.rs
@@ -1,6 +1,7 @@
 extern crate mit_commit_message_lints;
 
 use std::env;
+use std::{convert::TryFrom, path::PathBuf};
 
 use mit_commit_message_lints::{
     external,
@@ -9,7 +10,6 @@ use mit_commit_message_lints::{
 
 use crate::cli::app;
 use crate::errors::MitCommitMsgError;
-use std::{convert::TryFrom, path::PathBuf};
 
 fn main() -> Result<(), MitCommitMsgError> {
     let matches = app().get_matches();

--- a/mit-commit-msg/src/main.rs
+++ b/mit-commit-msg/src/main.rs
@@ -28,7 +28,7 @@ fn main() -> Result<(), MitCommitMsgError> {
     let mut git_config = external::Git2::try_from(current_dir)?;
     let lint_config = Lints::get_from_toml_or_else_vcs(&toml, &mut git_config)?;
 
-    let lint_problems = lint(&commit_message, lint_config);
+    let lint_problems = lint(&commit_message.clone().into(), lint_config);
     let output = format_lint_problems(&commit_message, lint_problems);
 
     if let Some((message, exit_code)) = output {

--- a/mit-pre-commit/build.rs
+++ b/mit-pre-commit/build.rs
@@ -1,12 +1,13 @@
-use clap_generate::generators::{Bash, Elvish, Fish, Zsh};
-
 use std::env;
 use std::path::PathBuf;
 
-#[path = "src/cli.rs"]
-mod cli;
+use clap_generate::generators::{Bash, Elvish, Fish, Zsh};
+
 use mit_build_tools::completion;
 use mit_build_tools::manpage;
+
+#[path = "src/cli.rs"]
+mod cli;
 
 fn main() {
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());

--- a/mit-pre-commit/src/errors.rs
+++ b/mit-pre-commit/src/errors.rs
@@ -1,5 +1,6 @@
-use mit_commit_message_lints::{author, external};
 use thiserror::Error;
+
+use mit_commit_message_lints::{author, external};
 
 #[derive(Error, Debug)]
 pub(crate) enum MitPreCommitError {

--- a/mit-pre-commit/src/main.rs
+++ b/mit-pre-commit/src/main.rs
@@ -1,9 +1,10 @@
+use std::convert::TryFrom;
 use std::{env, process};
+
+use mit_commit_message_lints::{author::vcs::get_coauthor_configuration, external::Git2};
 
 use crate::cli::app;
 use crate::errors::MitPreCommitError;
-use mit_commit_message_lints::{author::vcs::get_coauthor_configuration, external::Git2};
-use std::convert::TryFrom;
 
 #[repr(i32)]
 enum ExitCode {

--- a/mit-prepare-commit-msg/build.rs
+++ b/mit-prepare-commit-msg/build.rs
@@ -1,12 +1,13 @@
-use clap_generate::generators::{Bash, Elvish, Fish, Zsh};
-
 use std::env;
 use std::path::PathBuf;
 
-#[path = "src/cli.rs"]
-mod cli;
+use clap_generate::generators::{Bash, Elvish, Fish, Zsh};
+
 use mit_build_tools::completion;
 use mit_build_tools::manpage;
+
+#[path = "src/cli.rs"]
+mod cli;
 
 fn main() {
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());

--- a/mit-prepare-commit-msg/src/errors.rs
+++ b/mit-prepare-commit-msg/src/errors.rs
@@ -1,6 +1,7 @@
+use thiserror::Error;
+
 use mit_commit_message_lints::lints::CommitMessageError;
 use mit_commit_message_lints::{author, external, relates};
-use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub(crate) enum MitPrepareCommitMessageError {

--- a/mit-prepare-commit-msg/src/main.rs
+++ b/mit-prepare-commit-msg/src/main.rs
@@ -1,8 +1,7 @@
+use std::convert::TryFrom;
+use std::path::PathBuf;
 use std::{env, fs::File, io::Write};
 
-use crate::cli::app;
-use crate::errors::MitPrepareCommitMessageError;
-use crate::MitPrepareCommitMessageError::MissingCommitFilePath;
 use mit_commit_message_lints::relates::vcs::get_relate_to_configuration;
 use mit_commit_message_lints::{
     author::{entities::Author, vcs::get_coauthor_configuration},
@@ -10,8 +9,10 @@ use mit_commit_message_lints::{
     lints::lib::{CommitMessage, Trailer},
     relates::entities::RelateTo,
 };
-use std::convert::TryFrom;
-use std::path::PathBuf;
+
+use crate::cli::app;
+use crate::errors::MitPrepareCommitMessageError;
+use crate::MitPrepareCommitMessageError::MissingCommitFilePath;
 
 mod cli;
 mod errors;


### PR DESCRIPTION
- Order imports
- Remove hollow function
- Remove format
- Mirgate to new ast library
- Add linter for new line in subjct
- Push the commit class out of the lints
