### PR TITLE
build: Start using conventional commit log

### DIFF
--- a/.git-mit.toml.dist
+++ b/.git-mit.toml.dist
@@ -1,1 +1,3 @@
 [mit.lint]
+not-conventional-commit = true
+


### PR DESCRIPTION
This starts using a conventional commit log for our versioning system.
