### PR TITLE
fix: Add relates to to the duplicates list

### DIFF
--- a/docs/lints/index.md
+++ b/docs/lints/index.md
@@ -58,7 +58,7 @@ Lints relating to trailers:
 
 ##### duplicated-trailers
 
-Detect duplicated `Signed-off-by` and `Co-authored-by` Trailers.
+Detect duplicated `Signed-off-by`, `Co-authored-by`, and `Relates-to` Trailers.
 
 ###### Default status
 
@@ -110,6 +110,8 @@ Co-authored-by: Billie Thompson <billie@example.com>
 Co-authored-by: Billie Thompson <billie@example.com>
 Signed-off-by: Someone Else <someone@example.com>
 Signed-off-by: Someone Else <someone@example.com>
+Relates-to: #315
+Relates-to: #315
 ```
 
 Committing will fail.
@@ -129,13 +131,15 @@ Co-authored-by: Billie Thompson <billie@example.com>
 Co-authored-by: Billie Thompson <billie@example.com>
 Signed-off-by: Someone Else <someone@example.com>
 Signed-off-by: Someone Else <someone@example.com>
+Relates-to: #315
+Relates-to: #315
 
 
 ---
 
 Your commit message has duplicated trailers
 
-You can fix this by deleting the duplicated "Co-authored-by", "Signed-off-by" fields
+You can fix this by deleting the duplicated "Co-authored-by", "Relates-to", "Signed-off-by" fields
 ```
 
 #### Git Manual Style

--- a/docs/mit-relates-to.md
+++ b/docs/mit-relates-to.md
@@ -61,6 +61,35 @@ Wrote a great README
 Relates-to: [#12321513]
 ```
 
+We don't duplicate the ID if you manually type in the trailer
+
+```shell,script(name="3", expected_exit_code=0)
+echo "Some change" >> README.md
+git add README.md
+git mit bt
+git commit -m "Wrote a great README
+
+Relates-to: [#12321513]
+"
+```
+
+the commit message will contain the ID
+
+```shell,script(name="4", expected_exit_code=0)
+git show --pretty='format:author: [%an %ae] signed-by: [%GS] 
+---
+%B' -q
+```
+
+```text,verify(script_name="4", stream=stdout)
+author: [Billie Thompson billie@example.com] signed-by: [] 
+---
+Wrote a great README
+
+Relates-to: [#12321513]
+```
+
+
 This times out after 60 minuites, and is configurable with the
 `GIT_MIT_RELATES_TO_TIMEOUT` by environment variable.
 

--- a/docs/mit.md
+++ b/docs/mit.md
@@ -189,6 +189,31 @@ Second Commit
 Co-authored-by: Anyone Else <anyone@example.com>
 ```
 
+If for some reason you've already added the author we won't duplicate it
+
+```shell,script(name="9", expected_exit_code=0)
+echo "Lorem Ipsum" >> README.md
+
+git commit --all --message="Second Commit
+
+Co-authored-by: Anyone Else <anyone@example.com>
+" --quiet
+git show --pretty='format:author: [%an %ae] signed-by: [%GS] 
+---
+%B' -q
+```
+
+The author configuration will be updated like this
+
+```text,verify(script_name="9", stream=stdout)
+author: [Someone Else se@example.com] signed-by: [] 
+---
+Second Commit
+
+Co-authored-by: Anyone Else <anyone@example.com>
+```
+
+
 The command also works with signed commits
 
 The `bt` user has a valid gpg key.

--- a/mit-commit-message-lints/src/lints/checks/duplicate_trailers.rs
+++ b/mit-commit-message-lints/src/lints/checks/duplicate_trailers.rs
@@ -9,7 +9,8 @@ use crate::lints::lib::Problem;
 
 pub(crate) const CONFIG: &str = "duplicated-trailers";
 
-const TRAILERS_TO_CHECK_FOR_DUPLICATES: [&str; 2] = ["Signed-off-by", "Co-authored-by"];
+const TRAILERS_TO_CHECK_FOR_DUPLICATES: [&str; 3] =
+    ["Signed-off-by", "Co-authored-by", "Relates-to"];
 const FIELD_SINGULAR: &str = "field";
 const ERROR: &str = "Your commit message has duplicated trailers";
 
@@ -157,6 +158,28 @@ mod tests_has_duplicated_trailers {
             &Some(Problem::new(
                 ERROR.into(),
                 "You can fix this by deleting the duplicated \"Co-authored-by\" field".into(),
+                Code::DuplicatedTrailers,
+            )),
+        );
+    }
+
+    #[test]
+    fn relates_to() {
+        test_lint_duplicated_trailers(
+            indoc!(
+                "
+                An example commit
+
+                This is an example commit without any duplicate trailers
+
+                Relates-to: #315
+                Relates-to: #315
+                "
+            )
+            .into(),
+            &Some(Problem::new(
+                ERROR.into(),
+                "You can fix this by deleting the duplicated \"Relates-to\" field".into(),
                 Code::DuplicatedTrailers,
             )),
         );


### PR DESCRIPTION
This adds the relates to trailer to the list of trailers we detech
duplicates from, but the root of the problem is that we sometimes insert
a trailer when we don't actually need to, because it's already there.
This also fixes that.

Relates-to: #220
