### PR TITLE
fix: Centralise the git-mit console style

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,6 +841,7 @@ dependencies = [
 name = "mit-commit-message-lints"
 version = "3.93.4"
 dependencies = [
+ "comfy-table",
  "console",
  "criterion",
  "git2",

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ lint:
 ## Format what can be formatted
 fmt:
 	cargo fix --allow-dirty
-	cargo clippy --allow-dirty --fix -Z unstable-options --all-features -- -D warnings -Dclippy::all -D clippy::pedantic
+	cargo +nightly clippy --allow-dirty --fix -Z unstable-options --all-features -- -D warnings -Dclippy::all -D clippy::pedantic
 	cargo fmt --all
 	npx prettier --write **.yml
 

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ git mit-config lint available
 |-----------------------------------+----------|
 | jira-issue-key-missing            | disabled |
 |-----------------------------------+----------|
-| subject-not-separated-from-body   | enabled  |
-|-----------------------------------+----------|
 | github-id-missing                 | disabled |
+|-----------------------------------+----------|
+| subject-not-separated-from-body   | enabled  |
 |-----------------------------------+----------|
 | subject-longer-than-72-characters | enabled  |
 |-----------------------------------+----------|

--- a/docs/lints/index.md
+++ b/docs/lints/index.md
@@ -34,9 +34,9 @@ git mit-config lint available
 |-----------------------------------+----------|
 | jira-issue-key-missing            | disabled |
 |-----------------------------------+----------|
-| subject-not-separated-from-body   | enabled  |
-|-----------------------------------+----------|
 | github-id-missing                 | disabled |
+|-----------------------------------+----------|
+| subject-not-separated-from-body   | enabled  |
 |-----------------------------------+----------|
 | subject-longer-than-72-characters | enabled  |
 |-----------------------------------+----------|

--- a/git-mit-config/src/cmd/author_example.rs
+++ b/git-mit-config/src/cmd/author_example.rs
@@ -3,6 +3,7 @@ use std::convert::TryInto;
 use clap::ArgMatches;
 
 use crate::errors::GitMitConfigError;
+use mit_commit_message_lints::console::style::to_be_piped;
 use mit_commit_message_lints::mit::Authors;
 
 pub(crate) fn run_on_match(matches: &ArgMatches) -> Option<Result<(), GitMitConfigError>> {
@@ -14,7 +15,7 @@ pub(crate) fn run_on_match(matches: &ArgMatches) -> Option<Result<(), GitMitConf
 
 fn run() -> Result<(), GitMitConfigError> {
     let example: String = Authors::example().try_into()?;
-    println!("{}", example);
+    to_be_piped(&example);
 
     Ok(())
 }

--- a/git-mit-config/src/cmd/author_generate.rs
+++ b/git-mit-config/src/cmd/author_generate.rs
@@ -6,12 +6,11 @@ use std::{env, fs};
 use clap::ArgMatches;
 use xdg::BaseDirectories;
 
-use mit_commit_message_lints::mit::{get_config_authors, AuthorConfigParseError, Authors};
+use mit_commit_message_lints::mit::{get_config_authors, Authors};
 
 use crate::errors::GitMitConfigError;
 use crate::get_vcs;
-use crate::ExitCode::UnparsableAuthorFile;
-use console::style;
+
 use std::convert::{TryFrom, TryInto};
 
 const PROBABLY_SAFE_FALLBACK_SHELL: &str = "/bin/sh";
@@ -33,7 +32,7 @@ fn run(matches: &ArgMatches) -> Result<(), GitMitConfigError> {
     let all_authors = Authors::try_from(users_config.as_str());
 
     if let Err(error) = &all_authors {
-        exit_unparsable_exit_code(error)
+        mit_commit_message_lints::console::exit_unparsable_author(error)
     }
 
     let is_local = Some("local") == matches.value_of("scope");
@@ -44,7 +43,7 @@ fn run(matches: &ArgMatches) -> Result<(), GitMitConfigError> {
 
     let toml: String = all_authors?.merge(&vcs_authors).try_into()?;
 
-    println!("{}", toml);
+    mit_commit_message_lints::console::style::to_be_piped(&toml);
     Ok(())
 }
 
@@ -88,12 +87,4 @@ fn config_path(cargo_package_name: &str) -> Result<String, GitMitConfigError> {
 
 fn authors_config_file(config_directory: &BaseDirectories) -> Result<PathBuf, GitMitConfigError> {
     Ok(config_directory.place_config_file("mit.toml")?)
-}
-
-fn exit_unparsable_exit_code(parse_err: &AuthorConfigParseError) {
-    let error = style("Unable to parse the author config").red().bold();
-    let tip = style(format!("You can fix this by correcting the file so it's parsable\n\nYou can see a parsable example by running:\ngit mit-config mit example\n\nHere's the technical details, that might help you track down the source of the problem\n\n{}", parse_err)).italic();
-
-    eprintln!("{}\n\n{}", error, tip);
-    std::process::exit(UnparsableAuthorFile as i32);
 }

--- a/git-mit-config/src/cmd/lint_available.rs
+++ b/git-mit-config/src/cmd/lint_available.rs
@@ -1,10 +1,10 @@
 use clap::ArgMatches;
 
-use mit_commit_message_lints::lints::{Lint, Lints};
+use mit_commit_message_lints::lints::Lints;
 
 use crate::errors::GitMitConfigError;
 use crate::get_vcs;
-use comfy_table::Table;
+
 use mit_commit_message_lints::external;
 use std::env::current_dir;
 
@@ -21,24 +21,8 @@ fn run(matches: &ArgMatches) -> Result<(), GitMitConfigError> {
     let mut vcs = get_vcs(is_local, &current_dir)?;
     let toml = external::read_toml(current_dir)?;
 
-    let all_lints: Vec<Lint> = Lint::iterator().collect();
     let lints = Lints::get_from_toml_or_else_vcs(&toml, &mut vcs)?;
-    let mut table = Table::new();
-    table.set_header(vec!["Lint", "Status"]);
-
-    let rows: Table = all_lints.into_iter().fold(table, |mut table, lint| {
-        table.add_row(vec![
-            lint.name(),
-            if lints.clone().into_iter().any(|x| x == lint) {
-                "enabled"
-            } else {
-                "disabled"
-            },
-        ]);
-        table
-    });
-
-    println!("{}", rows);
+    mit_commit_message_lints::console::style::lint_table(Lints::available(), &lints);
 
     Ok(())
 }

--- a/git-mit-config/src/cmd/lint_disable.rs
+++ b/git-mit-config/src/cmd/lint_disable.rs
@@ -9,7 +9,6 @@ use mit_commit_message_lints::lints::Lints;
 use crate::errors::GitMitConfigError;
 use crate::errors::GitMitConfigError::LintNameNotGiven;
 use crate::get_vcs;
-use console::style;
 
 pub(crate) fn run_on_match(matches: &ArgMatches) -> Option<Result<(), GitMitConfigError>> {
     matches
@@ -29,10 +28,9 @@ fn run(matches: &ArgMatches) -> Result<(), GitMitConfigError> {
     let mut vcs = get_vcs(is_local, &current_dir)?;
     let toml = external::read_toml(current_dir)?;
     if !toml.is_empty() {
-        eprintln!(
-            "{}",
-            style("Warning: your config is overridden by a repository config file").bold()
-        );
+        mit_commit_message_lints::console::style::warning(
+            "Warning: your config is overridden by a repository config file",
+        )
     }
 
     let lints: Lints = subcommand

--- a/git-mit-config/src/cmd/lint_enable.rs
+++ b/git-mit-config/src/cmd/lint_enable.rs
@@ -9,7 +9,6 @@ use mit_commit_message_lints::lints::Lints;
 use crate::errors::GitMitConfigError;
 use crate::errors::GitMitConfigError::LintNameNotGiven;
 use crate::get_vcs;
-use console::style;
 
 pub(crate) fn run_on_match(matches: &ArgMatches) -> Option<Result<(), GitMitConfigError>> {
     matches
@@ -29,10 +28,9 @@ fn run(matches: &ArgMatches) -> Result<(), GitMitConfigError> {
     let mut vcs = get_vcs(is_local, &current_dir)?;
     let toml = external::read_toml(current_dir)?;
     if !toml.is_empty() {
-        eprintln!(
-            "{}",
-            style("Warning: your config is overridden by a repository config file").bold()
-        );
+        mit_commit_message_lints::console::style::warning(
+            "Warning: your config is overridden by a repository config file",
+        )
     }
 
     let lints: Lints = subcommand

--- a/git-mit-config/src/cmd/lint_enabled.rs
+++ b/git-mit-config/src/cmd/lint_enabled.rs
@@ -5,7 +5,6 @@ use mit_commit_message_lints::lints::Lints;
 
 use crate::errors::GitMitConfigError;
 use crate::{current_dir, get_vcs};
-use comfy_table::Table;
 
 pub(crate) fn run_on_match(matches: &ArgMatches) -> Option<Result<(), GitMitConfigError>> {
     matches
@@ -21,15 +20,7 @@ fn run(matches: &ArgMatches) -> Result<(), GitMitConfigError> {
     let toml = external::read_toml(current_dir)?;
 
     let lints = Lints::get_from_toml_or_else_vcs(&toml, &mut vcs)?;
-    let mut table = Table::new();
-    table.set_header(vec!["Lint", "Status"]);
-
-    let rows: Table = lints.into_iter().fold(table, |mut table, lint| {
-        table.add_row(vec![lint.name(), "enabled"]);
-        table
-    });
-
-    println!("{}", rows);
+    mit_commit_message_lints::console::style::lint_table(&lints, &lints);
 
     Ok(())
 }

--- a/git-mit-config/src/cmd/lint_generate.rs
+++ b/git-mit-config/src/cmd/lint_generate.rs
@@ -22,6 +22,8 @@ fn run(matches: &ArgMatches) -> Result<(), GitMitConfigError> {
 
     let output_toml: String =
         Lints::get_from_toml_or_else_vcs(&input_toml, &mut vcs)?.try_into()?;
-    println!("{}", output_toml);
+
+    mit_commit_message_lints::console::to_be_piped(&output_toml);
+
     Ok(())
 }

--- a/git-mit-config/src/cmd/lint_status.rs
+++ b/git-mit-config/src/cmd/lint_status.rs
@@ -1,7 +1,6 @@
 use std::convert::TryInto;
 
 use clap::ArgMatches;
-use comfy_table::Table;
 
 use mit_commit_message_lints::external;
 use mit_commit_message_lints::lints::Lints;
@@ -29,38 +28,10 @@ fn run(matches: &ArgMatches) -> Result<(), GitMitConfigError> {
 
     let lints = get_selected_lints(&subcommand_args)?;
     let config = Lints::get_from_toml_or_else_vcs(&toml, &mut vcs)?;
-    let status = get_config_status(lints.clone(), config);
-    let names = lints.names();
 
-    let mut table = Table::new();
-    table.set_header(vec!["Lint", "Status"]);
-
-    table = names
-        .into_iter()
-        .zip(status)
-        .fold(table, |mut table, (name, status_name)| {
-            table.add_row(vec![name, status_name]);
-            table
-        });
-
-    println!("{}", table);
+    mit_commit_message_lints::console::style::lint_table(&lints, &config);
 
     Ok(())
-}
-
-fn get_config_status<'a>(lints: Lints, config: Lints) -> Vec<&'a str> {
-    let enabled_lints: Vec<_> = config.into_iter().collect();
-
-    lints
-        .into_iter()
-        .map(|lint| {
-            if enabled_lints.contains(&lint) {
-                "enabled"
-            } else {
-                "disabled"
-            }
-        })
-        .collect::<Vec<_>>()
 }
 
 fn get_selected_lints(args: &ArgMatches) -> Result<Lints, GitMitConfigError> {

--- a/git-mit-config/src/main.rs
+++ b/git-mit-config/src/main.rs
@@ -13,11 +13,6 @@ mod cli;
 mod cmd;
 mod errors;
 
-#[repr(i32)]
-enum ExitCode {
-    UnparsableAuthorFile = 4,
-}
-
 fn main() -> Result<(), GitMitConfigError> {
     let lint_names: Vec<&str> = Lint::iterator()
         .map(mit_commit_message_lints::lints::Lint::name)

--- a/git-mit-install/src/main.rs
+++ b/git-mit-install/src/main.rs
@@ -52,11 +52,16 @@ fn install_hook(hook_path: &PathBuf, hook_name: &str) -> Result<(), GitMitInstal
     }
 
     if install_path.exists() {
-        eprintln!("Couldn't create hook at {}, it already exists, you need to remove this before continuing", install_path.to_string_lossy());
-
+        let mut tip = format!("Couldn't create hook at {}, it already exists, you need to remove this before continuing", install_path.to_string_lossy());
         if let Ok(dest) = install_path.read_link() {
-            eprintln!("looks like it's a symlink to {}", dest.to_string_lossy());
+            tip = format!(
+                "{}\nlooks like it's a symlink to {}",
+                tip,
+                dest.to_string_lossy()
+            );
         }
+
+        mit_commit_message_lints::console::style::problem("couldn't install hook", &tip);
 
         return Err(GitMitInstallError::ExistingHook);
     }

--- a/mit-commit-message-lints/Cargo.toml
+++ b/mit-commit-message-lints/Cargo.toml
@@ -24,6 +24,7 @@ toml = "0.5.6"
 mit-commit = "1.7.0"
 lazy_static = "1.4.0"
 console = "0.11.3"
+comfy-table = "1.0.0"
 
   [dependencies.serde]
   version = "1.0.114"

--- a/mit-commit-message-lints/src/console/exit.rs
+++ b/mit-commit-message-lints/src/console/exit.rs
@@ -1,0 +1,101 @@
+use std::error::Error;
+
+use crate::console::exit::Code::{InitialNotMatchedToAuthor, UnparsableAuthorFile};
+use crate::lints::Problem;
+use console::style;
+use mit_commit::CommitMessage;
+use std::process;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(i32)]
+pub enum Code {
+    InitialNotMatchedToAuthor = 3,
+    UnparsableAuthorFile,
+    StaleAuthor,
+    DuplicatedTrailers,
+    PivotalTrackerIdMissing,
+    JiraIssueKeyMissing,
+    GitHubIdMissing,
+    SubjectNotSeparateFromBody,
+    SubjectLongerThan72Characters,
+    SubjectNotCapitalized,
+    SubjectEndsWithPeriod,
+    BodyWiderThan72Characters,
+    NotConventionalCommit,
+    NotEmojiLog,
+}
+
+pub fn unparsable_author(parse_err: &dyn Error) {
+    super::style::problem("Unable to parse the author config", &format!("You can fix this by correcting the file so it's parsable\n\nYou can see a parsable example by running:\ngit mit-config mit example\n\nHere's the technical details, that might help you track down the source of the problem\n\n{}", parse_err));
+    std::process::exit(UnparsableAuthorFile as i32);
+}
+
+pub fn initial_not_matched_to_author(initials_without_authors: &[&str]) {
+    super::style::problem(
+        &format!(
+            "Could not find the initials {}.",
+            initials_without_authors.join(", ")
+        ),
+        "You can fix this by checking the initials are in the configuration file.",
+    );
+    std::process::exit(InitialNotMatchedToAuthor as i32);
+}
+
+pub fn stale_author() {
+    crate::console::style::problem("The details of the mit of this commit are stale", "Can you confirm who's currently coding?\n\nIt's nice to get and give the right credit.\n\nYou can fix this by running `git mit` then the initials of whoever is coding for example:\ngit mit bt\ngit mit bt se\n");
+
+    process::exit(Code::StaleAuthor as i32);
+}
+
+fn format_lint_problems(
+    original_message: &CommitMessage,
+    lint_problems: Vec<Problem>,
+) -> Option<(String, Code)> {
+    let (_, message_and_code) = lint_problems.into_iter().fold(
+        (original_message, None),
+        |(commit_message, output), problem| {
+            (
+                commit_message,
+                match output {
+                    Some((existing_output, _)) => Some((
+                        {
+                            let error = style(problem.error()).red().bold();
+                            let tip = style(problem.tip()).italic();
+
+                            format!("{}\n\n{}\n\n{}", existing_output, error, tip)
+                        },
+                        *(problem.code()),
+                    )),
+                    None => Some((
+                        {
+                            let error = style(problem.error()).red().bold();
+                            let tip = style(problem.tip()).italic();
+
+                            format!(
+                                "{}\n\n---\n\n{}\n\n{}",
+                                String::from(commit_message.clone()),
+                                error,
+                                tip
+                            )
+                        },
+                        *(problem.code()),
+                    )),
+                },
+            )
+        },
+    );
+    message_and_code
+}
+
+pub fn lint_problem(commit_message: &CommitMessage, lint_problems: Vec<Problem>) {
+    let output = format_lint_problems(&commit_message, lint_problems);
+
+    if let Some((message, exit_code)) = output {
+        display_lint_err_and_exit(&message, exit_code)
+    }
+}
+fn display_lint_err_and_exit(commit_message: &str, exit_code: Code) {
+    eprintln!("{}", commit_message);
+
+    std::process::exit(exit_code as i32);
+}

--- a/mit-commit-message-lints/src/console/mod.rs
+++ b/mit-commit-message-lints/src/console/mod.rs
@@ -1,0 +1,9 @@
+pub(crate) mod exit;
+pub mod style;
+
+pub use exit::initial_not_matched_to_author as exit_initial_not_matched_to_author;
+pub use exit::lint_problem as exit_lint_problem;
+pub use exit::stale_author as exit_stale_author;
+pub use exit::unparsable_author as exit_unparsable_author;
+pub use exit::Code as ExitCode;
+pub use style::to_be_piped;

--- a/mit-commit-message-lints/src/console/style.rs
+++ b/mit-commit-message-lints/src/console/style.rs
@@ -1,0 +1,34 @@
+use crate::lints::Lints;
+use comfy_table::Table;
+use console::style;
+
+pub fn problem(error: &str, tip: &str) {
+    eprintln!("{}\n\n{}", style(error).red().bold(), style(tip).italic());
+}
+
+pub fn warning(warning: &str) {
+    eprintln!("{}", style(warning).yellow().bold());
+}
+
+pub fn to_be_piped(output: &str) {
+    println!("{}", output)
+}
+
+pub fn lint_table(list: &Lints, enabled: &Lints) {
+    let mut table = Table::new();
+    table.set_header(vec!["Lint", "Status"]);
+
+    let rows: Table = list.clone().into_iter().fold(table, |mut table, lint| {
+        table.add_row(vec![
+            lint.name(),
+            if enabled.clone().into_iter().any(|x| x == lint) {
+                "enabled"
+            } else {
+                "disabled"
+            },
+        ]);
+        table
+    });
+
+    println!("{}", rows);
+}

--- a/mit-commit-message-lints/src/lib.rs
+++ b/mit-commit-message-lints/src/lib.rs
@@ -2,6 +2,7 @@
 extern crate lazy_static;
 extern crate serde;
 
+pub mod console;
 pub mod external;
 pub mod lints;
 pub mod mit;

--- a/mit-commit-message-lints/src/lints/checks/body_wider_than_72_characters.rs
+++ b/mit-commit-message-lints/src/lints/checks/body_wider_than_72_characters.rs
@@ -1,6 +1,6 @@
 use mit_commit::CommitMessage;
 
-use crate::lints::lib::Code;
+use crate::console::exit::Code;
 use crate::lints::lib::Problem;
 
 pub(crate) const CONFIG: &str = "body-wider-than-72-characters";

--- a/mit-commit-message-lints/src/lints/checks/duplicate_trailers.rs
+++ b/mit-commit-message-lints/src/lints/checks/duplicate_trailers.rs
@@ -4,7 +4,7 @@ use std::ops::Add;
 use mit_commit::CommitMessage;
 use mit_commit::Trailer as NgTrailer;
 
-use crate::lints::lib::Code;
+use crate::console::exit::Code;
 use crate::lints::lib::Problem;
 
 pub(crate) const CONFIG: &str = "duplicated-trailers";

--- a/mit-commit-message-lints/src/lints/checks/missing_github_id.rs
+++ b/mit-commit-message-lints/src/lints/checks/missing_github_id.rs
@@ -2,7 +2,7 @@ use indoc::indoc;
 use mit_commit::CommitMessage;
 use regex::Regex;
 
-use crate::lints::lib::Code;
+use crate::console::exit::Code;
 use crate::lints::lib::Problem;
 
 pub(crate) const CONFIG: &str = "github-id-missing";

--- a/mit-commit-message-lints/src/lints/checks/missing_jira_issue_key.rs
+++ b/mit-commit-message-lints/src/lints/checks/missing_jira_issue_key.rs
@@ -1,7 +1,7 @@
 use mit_commit::CommitMessage;
 use regex::Regex;
 
-use crate::lints::lib::Code;
+use crate::console::exit::Code;
 use crate::lints::lib::Problem;
 
 pub(crate) const CONFIG: &str = "jira-issue-key-missing";

--- a/mit-commit-message-lints/src/lints/checks/missing_pivotal_tracker_id.rs
+++ b/mit-commit-message-lints/src/lints/checks/missing_pivotal_tracker_id.rs
@@ -2,7 +2,7 @@ use indoc::indoc;
 use mit_commit::CommitMessage;
 use regex::Regex;
 
-use crate::lints::lib::Code;
+use crate::console::exit::Code;
 use crate::lints::lib::Problem;
 
 pub(crate) const CONFIG: &str = "pivotal-tracker-id-missing";

--- a/mit-commit-message-lints/src/lints/checks/not_conventional_commit.rs
+++ b/mit-commit-message-lints/src/lints/checks/not_conventional_commit.rs
@@ -2,7 +2,7 @@ use indoc::indoc;
 use mit_commit::CommitMessage;
 use regex::Regex;
 
-use crate::lints::lib::Code;
+use crate::console::exit::Code;
 use crate::lints::lib::Problem;
 
 pub(crate) const CONFIG: &str = "not-conventional-commit";

--- a/mit-commit-message-lints/src/lints/checks/not_emoji_log.rs
+++ b/mit-commit-message-lints/src/lints/checks/not_emoji_log.rs
@@ -1,7 +1,7 @@
 use indoc::indoc;
 use mit_commit::CommitMessage;
 
-use crate::lints::lib::Code;
+use crate::console::exit::Code;
 use crate::lints::lib::Problem;
 
 pub(crate) const CONFIG: &str = "not-emoji-log";

--- a/mit-commit-message-lints/src/lints/checks/subject_line_ends_with_period.rs
+++ b/mit-commit-message-lints/src/lints/checks/subject_line_ends_with_period.rs
@@ -1,6 +1,6 @@
 use mit_commit::CommitMessage;
 
-use crate::lints::lib::Code;
+use crate::console::exit::Code;
 use crate::lints::lib::Problem;
 
 pub(crate) const CONFIG: &str = "subject-line-ends-with-period";
@@ -9,11 +9,7 @@ const ERROR: &str = "Your commit message ends with a period";
 const HELP_MESSAGE: &str = "You can fix this by removing the period";
 
 fn has_problem(commit_message: &CommitMessage) -> bool {
-    if let Some('.') = commit_message.get_subject().chars().rev().next() {
-        true
-    } else {
-        false
-    }
+    matches!(commit_message.get_subject().chars().rev().next(), Some('.'))
 }
 
 pub(crate) fn lint(commit_message: &CommitMessage) -> Option<Problem> {

--- a/mit-commit-message-lints/src/lints/checks/subject_longer_than_72_characters.rs
+++ b/mit-commit-message-lints/src/lints/checks/subject_longer_than_72_characters.rs
@@ -1,6 +1,6 @@
 use mit_commit::CommitMessage;
 
-use crate::lints::lib::Code;
+use crate::console::exit::Code;
 use crate::lints::lib::Problem;
 
 pub(crate) const CONFIG: &str = "subject-longer-than-72-characters";

--- a/mit-commit-message-lints/src/lints/checks/subject_not_capitalized.rs
+++ b/mit-commit-message-lints/src/lints/checks/subject_not_capitalized.rs
@@ -1,6 +1,6 @@
 use mit_commit::CommitMessage;
 
-use crate::lints::lib::Code;
+use crate::console::exit::Code;
 use crate::lints::lib::Problem;
 
 pub(crate) const CONFIG: &str = "subject-line-not-capitalized";
@@ -9,11 +9,13 @@ const HELP_MESSAGE: &str = "You can fix this by capitalising the first character
 const ERROR: &str = "Your commit message is missing a capital letter";
 
 fn has_problem(commit_message: &CommitMessage) -> bool {
-    if let Some(character) = commit_message.get_subject().chars().next() {
-        character.to_string() != character.to_uppercase().to_string()
-    } else {
-        false
-    }
+    commit_message
+        .get_subject()
+        .chars()
+        .next()
+        .map_or(false, |character| {
+            character.to_string() != character.to_uppercase().to_string()
+        })
 }
 
 pub(crate) fn lint(commit_message: &CommitMessage) -> Option<Problem> {

--- a/mit-commit-message-lints/src/lints/checks/subject_not_seperate_from_body.rs
+++ b/mit-commit-message-lints/src/lints/checks/subject_not_seperate_from_body.rs
@@ -1,6 +1,6 @@
 use mit_commit::CommitMessage;
 
-use crate::lints::lib::Code;
+use crate::console::exit::Code;
 use crate::lints::lib::Problem;
 
 pub(crate) const CONFIG: &str = "subject-not-separated-from-body";

--- a/mit-commit-message-lints/src/lints/lib/mod.rs
+++ b/mit-commit-message-lints/src/lints/lib/mod.rs
@@ -2,7 +2,7 @@ pub use lint::Error as LintError;
 pub use lint::Lint;
 pub use lints::Error as LintsError;
 pub use lints::Lints;
-pub use problem::{Code, Problem};
+pub use problem::Problem;
 
 mod lint;
 mod lints;

--- a/mit-commit-message-lints/src/lints/lib/problem.rs
+++ b/mit-commit-message-lints/src/lints/lib/problem.rs
@@ -1,3 +1,5 @@
+use crate::console::exit::Code;
+
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct Problem {
     error: String,
@@ -25,27 +27,12 @@ impl Problem {
     }
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
-#[repr(i32)]
-pub enum Code {
-    DuplicatedTrailers = 3,
-    PivotalTrackerIdMissing,
-    JiraIssueKeyMissing,
-    GitHubIdMissing,
-    SubjectNotSeparateFromBody,
-    SubjectLongerThan72Characters,
-    SubjectNotCapitalized,
-    SubjectEndsWithPeriod,
-    BodyWiderThan72Characters,
-    NotConventionalCommit,
-    NotEmojiLog,
-}
-
 #[cfg(test)]
 mod tests {
     use pretty_assertions::assert_eq;
 
-    use crate::lints::{Code, Problem};
+    use crate::console::exit::Code;
+    use crate::lints::Problem;
 
     #[test]
     fn test_has_error() {

--- a/mit-commit-message-lints/src/lints/mod.rs
+++ b/mit-commit-message-lints/src/lints/mod.rs
@@ -1,7 +1,6 @@
 pub use cmd::lint;
 pub use cmd::set_status;
 pub use cmd::SetStatusError;
-pub use lib::Code;
 pub use lib::Lint;
 pub use lib::LintError;
 pub use lib::Lints;

--- a/mit-commit-message-lints/src/mit/cmd/vcs.rs
+++ b/mit-commit-message-lints/src/mit/cmd/vcs.rs
@@ -22,11 +22,7 @@ pub(crate) fn has_vcs_coauthor(config: &dyn Vcs, index: i32) -> bool {
     let email = get_vcs_coauthor_config(config, "email", index);
     let name = get_vcs_coauthor_config(config, "name", index);
 
-    if let (Ok(Some(_)), Ok(Some(_))) = (name, email) {
-        true
-    } else {
-        false
-    }
+    matches!((name, email), (Ok(Some(_)), Ok(Some(_))))
 }
 
 pub(crate) fn get_vcs_coauthor_config<'a>(

--- a/mit-pre-commit/src/main.rs
+++ b/mit-pre-commit/src/main.rs
@@ -1,18 +1,11 @@
 use std::convert::TryFrom;
-use std::{env, process};
-
-use console::style;
+use std::env;
 
 use mit_commit_message_lints::external::Git2;
 
 use crate::cli::app;
 use crate::errors::MitPreCommitError;
 use mit_commit_message_lints::mit::get_commit_coauthor_configuration;
-
-#[repr(i32)]
-enum ExitCode {
-    StaleAuthor = 3,
-}
 
 fn main() -> Result<(), errors::MitPreCommitError> {
     app().get_matches();
@@ -23,13 +16,7 @@ fn main() -> Result<(), errors::MitPreCommitError> {
     let co_author_configuration = get_commit_coauthor_configuration(&mut git_config)?;
 
     if co_author_configuration.is_none() {
-        let error = style("The details of the mit of this commit are stale")
-            .red()
-            .bold();
-        let tip = style("Can you confirm who's currently coding?\n\nIt's nice to get and give the right credit.\n\nYou can fix this by running `git mit` then the initials of whoever is coding for example:\ngit mit bt\ngit mit bt se\n").italic();
-        eprintln!("{}\n\n{}", error, tip);
-
-        process::exit(ExitCode::StaleAuthor as i32);
+        mit_commit_message_lints::console::exit_stale_author();
     }
 
     Ok(())


### PR DESCRIPTION
This centralises the way we style the git error messages

Should fix #312
