### PR TITLE
fix: Add missing docs

### DIFF
--- a/git-mit/docs/manpage.template.md
+++ b/git-mit/docs/manpage.template.md
@@ -55,33 +55,45 @@ Common Tasks
 
 You can install git-mit into a new repository using
 
-```shell script
+```shell
 git mit-install
 ```
 
 You can add a new author to that repository by running
 
-```shell script
+```shell
 git mit-config mit set eg "Egg Sample" egg.sample@example.com
 ```
 
 You can save that author permanently by running
 
-```shell script
+```shell
 git mit-config mit set eg "Egg Sample" egg.sample@example.com
 git mit-config mit generate > $HOME/.config/git-mit/mit.yml
 ```
 
 You can disable a lint by running
 
-```shell script
+```shell
 git mit-config lint disable jira-issue-key-missing
 ```
 
 You can install the example authors file to the default location with
 
-```shell script
+```shell
 git mit-config mit example > $HOME/.config/git-mit/mit.yml
+```
+
+You can set the current author, and Co-authors by running
+
+```shell
+git mit ae se
+```
+
+You can populate the `Relates-to` trailer using
+
+```shell
+git mit-relates-to "[#12345678]"
 ```
 
 BUGS

--- a/git-mit/src/cli.rs
+++ b/git-mit/src/cli.rs
@@ -30,6 +30,14 @@ pub fn app() -> App<'static> {
                 You can install the example authors file to the default location with
 
                     git mit-config mit example > $HOME/.config/git-mit/mit.yml
+
+                You can set the current author, and Co-authors by running
+
+                    git mit ae se
+
+                You can populate the `Relates-to` trailer using
+
+                    git mit-relates-to \"[#12345678]\"
             "
         ))
         .arg(


### PR DESCRIPTION
This adds the missing documentation, and corrects the formatting of the
man page
