### PR TITLE
fix(src): Ensure there is always a space before trailers

### DIFF
--- a/docs/mit-relates-to.md
+++ b/docs/mit-relates-to.md
@@ -42,7 +42,7 @@ Next time you commit
 ``` shell,script(name="commit",expected_exit_code=0)
 git add README.md
 git mit bt
-git commit -m "Wrote a great README"
+git commit -m "docs: Wrote a great README"
 ```
 
 the commit message will contain the ID
@@ -56,7 +56,7 @@ git show --pretty='format:author: [%an %ae] signed-by: [%GS]
 ``` text,verify(script_name="show-log",stream=stdout)
 author: [Billie Thompson billie@example.com] signed-by: [] 
 ---
-Wrote a great README
+docs: Wrote a great README
 
 Relates-to: [#12321513]
 ```

--- a/docs/mit.md
+++ b/docs/mit.md
@@ -189,7 +189,7 @@ So next time we commit
 ``` shell,script(name="9",expected_exit_code=0)
 echo "Lorem Ipsum" >> README.md
 
-git commit --all --message="Second Commit" --quiet
+git commit --all --message="chore: Second Commit" --quiet
 git show --pretty='format:author: [%an %ae] signed-by: [%GS] 
 ---
 %B' -q
@@ -200,7 +200,7 @@ The author configuration will be updated like this
 ``` text,verify(script_name="9",stream=stdout)
 author: [Someone Else se@example.com] signed-by: [] 
 ---
-Second Commit
+chore: Second Commit
 
 Co-authored-by: Anyone Else <anyone@example.com>
 ```


### PR DESCRIPTION
There is some instances where a gap is not put before trailers

This can subseqently cause lints to fail. This will change the
body to make sure that we always have a gap
