### PR TITLE
Error if  runs outside a git repo

### DIFF
--- a/git-mit/src/errors.rs
+++ b/git-mit/src/errors.rs
@@ -3,6 +3,11 @@ use std::fmt::Display;
 use miette::{Diagnostic, LabeledSpan, SourceCode};
 use thiserror::Error;
 
+#[derive(Error, Diagnostic, Debug)]
+#[error("no repository")]
+#[diagnostic(help("To add an author run `git mit` from a git repository"))]
+pub struct NoRepository {}
+
 #[derive(Error, Debug)]
 #[error("could not find initial")]
 pub struct UnknownAuthor {

--- a/git-mit/src/main.rs
+++ b/git-mit/src/main.rs
@@ -15,6 +15,7 @@ use std::{convert::TryFrom, env, io::stdout, time::Duration};
 
 use clap::{CommandFactory, Parser};
 use clap_complete::generate;
+use errors::NoRepository;
 use git2::Repository;
 use miette::{IntoDiagnostic, Result};
 use mit_commit_message_lints::{
@@ -44,7 +45,11 @@ fn main() -> Result<()> {
     let file_authors = get_authors(&cli_args)?;
     let authors = file_authors.merge(&Authors::try_from(&git_config)?);
 
-    if repo_present() && !is_hook_present() {
+    if !repo_present() {
+        return Err(NoRepository {}.into());
+    }
+
+    if !is_hook_present() {
         not_setup_warning();
     };
 


### PR DESCRIPTION
This PR proposes to solve: https://github.com/PurpleBooth/git-mit/issues/397

The solution suggested is to err if git-mit is run from outside a config repo (this does not impact the other commands, git mit-config etc). To ensure that you can only set authors within the scope of a repository.

If you attempt to run the command from outside of a git repo you can expect the error:

```sh
Error:   × no repository
  help: To add an author run `git mit` from a git repository
```