### PR TITLE
feat: support lefthook by falling back to COMMIT_EDITMSG

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -19,6 +19,8 @@ jobs:
     uses: PurpleBooth/common-pipelines/.github/workflows/specdown-check.yml@main
     with:
       ubuntu_before_script: sudo apt-get install -y libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev && npm install -g lefthook
+      mac_before_script: brew install lefthook
+      windows_before_script: npm install -g lefthook
 
   release:
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -18,7 +18,7 @@ jobs:
   specdown:
     uses: PurpleBooth/common-pipelines/.github/workflows/specdown-check.yml@main
     with:
-      ubuntu_before_script: sudo apt-get install -y libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev
+      ubuntu_before_script: sudo apt-get install -y libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev && npm install -g lefthook
 
   release:
     if: github.ref == 'refs/heads/main'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,6 +1013,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "shell-words",
+ "tempfile",
  "thiserror",
  "time",
  "toml",

--- a/docs/binaries/mit-commit-msg.md
+++ b/docs/binaries/mit-commit-msg.md
@@ -15,15 +15,27 @@ Validate the commit message that a user has input
 Usage: mit-commit-msg [OPTIONS] [COMMIT_FILE_PATH]
 
 Arguments:
-  [COMMIT_FILE_PATH]  Path to a temporary file that contains the commit message written by the
-                      developer
+  [COMMIT_FILE_PATH]
+          Path to a temporary file that contains the commit message written by the developer
+          
+          When omitted the hook falls back to `<gitdir>/COMMIT_EDITMSG`, which is useful when the
+          hook is invoked via a hook manager like lefthook that does not forward git's positional
+          argument.
 
 Options:
-      --copy-message-to-clipboard  On lint failure copy the message to clipboard [env:
-                                   GIT_MIT_COPY_MESSAGE_TO_CLIPBOARD=]
-      --completion <COMPLETION>    [possible values: bash, elvish, fish, powershell, zsh]
-  -h, --help                       Print help
-  -V, --version                    Print version
+      --copy-message-to-clipboard
+          On lint failure copy the message to clipboard
+          
+          [env: GIT_MIT_COPY_MESSAGE_TO_CLIPBOARD=]
+
+      --completion <COMPLETION>
+          [possible values: bash, elvish, fish, powershell, zsh]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
 ```
 
 You can generate completion with
@@ -32,17 +44,13 @@ You can generate completion with
 mit-commit-msg --completion bash
 ```
 
-Otherwise, you need the commit file path
+When no commit file path is provided — for example when a hook manager like
+[lefthook](https://github.com/evilmartians/lefthook) invokes the hook
+without forwarding git's positional argument — the hook falls back to
+reading the commit message from `.git/COMMIT_EDITMSG`.
 
-``` shell,script(name="missing-commit-path-error",expected_exit_code=2)
+``` shell,script(name="no-argument-fallback",expected_exit_code=0)
+git init .
+printf 'Add a feature\n' > .git/COMMIT_EDITMSG
 mit-commit-msg
-```
-
-``` shell,verify(script_name="missing-commit-path-error",stream=stderr)
-error: the following required arguments were not provided:
-  <COMMIT_FILE_PATH>
-
-Usage: mit-commit-msg <COMMIT_FILE_PATH>
-
-For more information, try '--help'.
 ```

--- a/docs/binaries/mit-prepare-commit-msg.md
+++ b/docs/binaries/mit-prepare-commit-msg.md
@@ -18,6 +18,10 @@ Usage: mit-prepare-commit-msg [OPTIONS] [COMMIT_MESSAGE_PATH] [COMMIT_MESSAGE_SO
 Arguments:
   [COMMIT_MESSAGE_PATH]
           The name of the file that contains the commit log message
+          
+          When omitted the hook falls back to `<gitdir>/COMMIT_EDITMSG`, which is useful when the
+          hook is invoked via a hook manager like lefthook that does not forward git's positional
+          argument.
 
   [COMMIT_MESSAGE_SOURCE]
           The commit message, and can be: message (if a -m or -F option was given to git); template
@@ -64,17 +68,22 @@ You can generate completion with
 mit-prepare-commit-msg --completion bash
 ```
 
-Otherwise, you need a commit message path
+When no commit message path is provided — for example when a hook manager
+like [lefthook](https://github.com/evilmartians/lefthook) invokes the hook
+without forwarding git's positional argument — the hook falls back to
+reading from `.git/COMMIT_EDITMSG`.
 
-``` shell,script(name="missing-commit-path-error",expected_exit_code=2)
+``` shell,script(name="no-argument-fallback",expected_exit_code=0)
+git init --quiet .
+git mit bt se
+printf 'Add a feature\n' > .git/COMMIT_EDITMSG
 mit-prepare-commit-msg
+cat .git/COMMIT_EDITMSG
 ```
 
-``` shell,verify(script_name="missing-commit-path-error",stream=stderr)
-error: the following required arguments were not provided:
-  <COMMIT_MESSAGE_PATH>
+``` text,verify(script_name="no-argument-fallback",stream=stdout)
+Add a feature
 
-Usage: mit-prepare-commit-msg <COMMIT_MESSAGE_PATH> [COMMIT_MESSAGE_SOURCE] [COMMIT_SHA]
 
-For more information, try '--help'.
+Co-authored-by: Someone Else <someone@example.com>
 ```

--- a/docs/lefthook.md
+++ b/docs/lefthook.md
@@ -1,0 +1,87 @@
+# Lefthook integration
+
+[lefthook](https://github.com/evilmartians/lefthook) is a popular git hook
+manager. When lefthook takes over a repository's hooks it replaces the hook
+scripts in `.git/hooks` with its own runner and backs the originals up as
+`*.old` symlinks. Lefthook then invokes the configured commands but, unlike
+git, does **not** forward the positional arguments (such as the commit-message
+file path) to those commands.
+
+This means that when lefthook runs `mit-commit-msg` and
+`mit-prepare-commit-msg` the commit-message path argument is missing. The
+hooks fall back to `<gitdir>/COMMIT_EDITMSG` so co-author trailers and lints
+continue to work.
+
+## Setup
+
+We need a git repository with the hooks installed.
+
+```shell,script(name="init-repo",expected_exit_code=0)
+git init .
+```
+
+```shell,script(name="install-hooks",expected_exit_code=0)
+git mit-install
+```
+
+```shell,script(name="set-author",expected_exit_code=0)
+git mit bt se
+```
+
+## Configuring lefthook
+
+We tell lefthook to run all three git-mit hooks. No `{1}` argument forwarding
+is needed.
+
+```yaml,file(path="lefthook.yml")
+---
+pre-commit:
+  commands:
+    git-mit:
+      run: mit-pre-commit
+
+prepare-commit-msg:
+  commands:
+    git-mit:
+      run: mit-prepare-commit-msg
+
+commit-msg:
+  commands:
+    git-mit:
+      run: mit-commit-msg
+```
+
+Installing lefthook takes over the hooks. The original git-mit symlinks are
+backed up as `*.old`.
+
+```shell,script(name="lefthook-install",expected_exit_code=0)
+lefthook install
+```
+
+```shell,script(name="verify-hooks-backed-up",expected_exit_code=0)
+ls .git/hooks/commit-msg.old .git/hooks/prepare-commit-msg.old .git/hooks/pre-commit.old
+```
+
+## Committing through lefthook
+
+When we commit, lefthook intercepts each hook and runs the git-mit binaries
+without forwarding the commit-message path. The co-author trailers still
+appear because the hooks fall back to `COMMIT_EDITMSG`.
+
+```shell,script(name="lefthook-commit",expected_exit_code=0)
+echo "# Hello, world!" > README.md
+
+git add .
+git commit --message="Add a feature" --quiet
+git show --pretty='format:author: [%an %ae] signed-by: [%GS]
+---
+%B' -q
+```
+
+```text,verify(script_name="lefthook-commit",stream=stdout)
+author: [Billie Thompson billie@example.com] signed-by: []
+---
+Add a feature
+
+Co-authored-by: Someone Else <someone@example.com>
+```

--- a/docs/lefthook.md
+++ b/docs/lefthook.md
@@ -2,10 +2,9 @@
 
 [lefthook](https://github.com/evilmartians/lefthook) is a popular git hook
 manager. When lefthook takes over a repository's hooks it replaces the hook
-scripts in `.git/hooks` with its own runner and backs the originals up as
-`*.old` symlinks. Lefthook then invokes the configured commands but, unlike
-git, does **not** forward the positional arguments (such as the commit-message
-file path) to those commands.
+scripts in `.git/hooks` with its own runner. Lefthook then invokes the
+configured commands but, unlike git, does **not** forward the positional
+arguments (such as the commit-message file path) to those commands.
 
 This means that when lefthook runs `mit-commit-msg` and
 `mit-prepare-commit-msg` the commit-message path argument is missing. The
@@ -51,15 +50,10 @@ commit-msg:
       run: mit-commit-msg
 ```
 
-Installing lefthook takes over the hooks. The original git-mit symlinks are
-backed up as `*.old`.
+Installing lefthook takes over the hooks.
 
 ```shell,script(name="lefthook-install",expected_exit_code=0)
 lefthook install
-```
-
-```shell,script(name="verify-hooks-backed-up",expected_exit_code=0)
-ls .git/hooks/commit-msg.old .git/hooks/prepare-commit-msg.old .git/hooks/pre-commit.old
 ```
 
 ## Committing through lefthook

--- a/mit-commit-message-lints/Cargo.toml
+++ b/mit-commit-message-lints/Cargo.toml
@@ -35,6 +35,7 @@ features = [ "derive" ]
 
 [dev-dependencies]
 criterion = "0.8.0"
+tempfile = "3.0.0"
 
 
 [[bench]]

--- a/mit-commit-message-lints/src/external/commit_message_path.rs
+++ b/mit-commit-message-lints/src/external/commit_message_path.rs
@@ -1,0 +1,88 @@
+//! Resolving the commit-message file path
+//!
+//! Git passes the path to the commit message file as the first positional
+//! argument to the `commit-msg` and `prepare-commit-msg` hooks. Hook
+//! managers such as [lefthook](https://github.com/evilmartians/lefthook)
+//! intercept these hooks but do not always forward that positional argument
+//! to the commands they run. When the argument is missing we fall back to
+//! the canonical location git writes the draft message to:
+//! `<gitdir>/COMMIT_EDITMSG`.
+
+use std::path::{Path, PathBuf};
+
+use git2::Repository;
+use miette::{IntoDiagnostic, Result};
+
+/// Resolve the path to the file containing the commit log message.
+///
+/// If `provided` is `Some` it is returned unchanged — this is the normal
+/// path when git invokes the hook directly.
+///
+/// If `provided` is `None` the git repository is discovered starting from
+/// `current_dir` and the path to `COMMIT_EDITMSG` inside the git directory
+/// is returned instead.
+///
+/// # Errors
+///
+/// If no path was provided and no git repository can be discovered from
+/// `current_dir`.
+pub fn resolve_commit_message_path(
+    provided: Option<PathBuf>,
+    current_dir: &Path,
+) -> Result<PathBuf> {
+    if let Some(path) = provided {
+        Ok(path)
+    } else {
+        let repo = Repository::discover(current_dir).into_diagnostic()?;
+        Ok(repo.path().join("COMMIT_EDITMSG"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::{Path, PathBuf};
+
+    use super::resolve_commit_message_path;
+    use git2::Repository;
+    use tempfile::TempDir;
+
+    #[test]
+    fn returns_provided_path_unchanged() {
+        let provided = PathBuf::from("/some/arbitrary/path");
+        let result = resolve_commit_message_path(Some(provided.clone()), Path::new("/tmp"));
+        assert_eq!(result.unwrap(), provided);
+    }
+
+    #[test]
+    fn defaults_to_commit_editmsg_when_not_provided() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path()).unwrap();
+        let expected = repo.path().join("COMMIT_EDITMSG");
+
+        let result = resolve_commit_message_path(None, temp.path());
+
+        assert_eq!(result.unwrap(), expected);
+    }
+
+    #[test]
+    fn discovers_repo_from_subdirectory() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path()).unwrap();
+        let expected = repo.path().join("COMMIT_EDITMSG");
+
+        let subdir = temp.path().join("nested/deep");
+        fs::create_dir_all(&subdir).unwrap();
+
+        let result = resolve_commit_message_path(None, &subdir);
+
+        assert_eq!(result.unwrap(), expected);
+    }
+
+    #[test]
+    fn errors_when_not_in_git_repo_and_not_provided() {
+        let temp = TempDir::new().unwrap();
+        let result = resolve_commit_message_path(None, temp.path());
+        assert!(result.is_err());
+    }
+}

--- a/mit-commit-message-lints/src/external/mod.rs
+++ b/mit-commit-message-lints/src/external/mod.rs
@@ -1,12 +1,14 @@
 //! Implementations of VCS we can interact with
 
 pub use self::{
+    commit_message_path::resolve_commit_message_path,
     config::read_toml,
     git2::Git2,
     in_memory::InMemory,
     vcs::{Error, RepoState, Vcs},
 };
 
+mod commit_message_path;
 mod config;
 mod git2;
 mod in_memory;

--- a/mit-commit-msg/src/cli.rs
+++ b/mit-commit-msg/src/cli.rs
@@ -9,7 +9,11 @@ use clap_complete::Shell;
 pub struct Args {
     /// Path to a temporary file that contains the commit message written by the
     /// developer
-    #[clap(index = 1, required_unless_present = "completion")]
+    ///
+    /// When omitted the hook falls back to `<gitdir>/COMMIT_EDITMSG`, which
+    /// is useful when the hook is invoked via a hook manager like lefthook
+    /// that does not forward git's positional argument.
+    #[clap(index = 1)]
     pub commit_file_path: Option<PathBuf>,
 
     /// On lint failure copy the message to clipboard

--- a/mit-commit-msg/src/errors.rs
+++ b/mit-commit-msg/src/errors.rs
@@ -5,13 +5,6 @@ use miette::{Diagnostic, LabeledSpan, Result, Severity, SourceCode};
 use mit_lint::Problem;
 use thiserror::Error;
 
-#[derive(Error, Debug, Diagnostic)]
-pub enum MitCommitMsgError {
-    #[error("expected file path name")]
-    #[diagnostic(code(mit_commit_msg::errors::mit_commit_msg_error::commit_path_missing))]
-    CommitPathMissing,
-}
-
 #[derive(Error, Debug)]
 #[error("multiple lint problems")]
 pub struct AggregateProblem(Vec<Problem>);

--- a/mit-commit-msg/src/main.rs
+++ b/mit-commit-msg/src/main.rs
@@ -48,12 +48,10 @@ async fn main() -> Result<()> {
         std::process::exit(0);
     }
 
-    let commit_file_path = cli_args
-        .commit_file_path
-        .ok_or(errors::MitCommitMsgError::CommitPathMissing)?;
-    let commit_message = CommitMessage::try_from(commit_file_path).into_diagnostic()?;
     let current_dir = env::current_dir().into_diagnostic()?;
-
+    let commit_file_path =
+        external::resolve_commit_message_path(cli_args.commit_file_path, &current_dir)?;
+    let commit_message = CommitMessage::try_from(commit_file_path).into_diagnostic()?;
     let toml = external::read_toml(current_dir.clone())?;
     let git_config = external::Git2::try_from(current_dir)?;
     let lint_config = read_from_toml_or_else_vcs(&toml, &git_config)?;

--- a/mit-prepare-commit-msg/src/cli.rs
+++ b/mit-prepare-commit-msg/src/cli.rs
@@ -9,7 +9,11 @@ use mit_commit_message_lints::mit::lib::non_clean_behaviour::BehaviourOption;
 #[clap(bin_name = "mit-prepare-commit-msg")]
 pub struct Args {
     /// The name of the file that contains the commit log message
-    #[clap(index = 1, required_unless_present = "completion")]
+    ///
+    /// When omitted the hook falls back to `<gitdir>/COMMIT_EDITMSG`,
+    /// which is useful when the hook is invoked via a hook manager like
+    /// lefthook that does not forward git's positional argument.
+    #[clap(index = 1)]
     pub commit_message_path: Option<PathBuf>,
 
     /// The commit message, and can be: message (if a -m or -F option was given

--- a/mit-prepare-commit-msg/src/errors.rs
+++ b/mit-prepare-commit-msg/src/errors.rs
@@ -3,10 +3,6 @@ use thiserror::Error;
 
 #[derive(Error, Debug, Diagnostic)]
 pub enum MitPrepareCommitMessageError {
-    #[error("Expected commit file path")]
-    #[diagnostic(code(mit_prepare_commit_msg::errors::missing_commit_file_path))]
-    MissingCommitFilePath,
-
     #[error("The relates-to exec command failed with exit code {exit_code}")]
     #[diagnostic(code(mit_prepare_commit_msg::errors::relates_to_exec_failed))]
     RelatesToExecFailed { exit_code: i32 },

--- a/mit-prepare-commit-msg/src/main.rs
+++ b/mit-prepare-commit-msg/src/main.rs
@@ -32,7 +32,7 @@ use miette::{IntoDiagnostic, Result};
 use mit_commit::{CommitMessage, Trailer};
 use mit_commit_message_lints::{
     console::error_handling::miette_install,
-    external::{Git2, RepoState, Vcs},
+    external::{self, Git2, RepoState, Vcs},
     mit::{
         cmd::get_config_non_clean_behaviour::get_config_non_clean_behaviour,
         get_commit_coauthor_configuration, lib::non_clean_behaviour::BehaviourOption, Author,
@@ -67,11 +67,9 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
-    let commit_message_path = cli_args
-        .commit_message_path
-        .ok_or(MitPrepareCommitMessageError::MissingCommitFilePath)?;
-
     let current_dir = env::current_dir().into_diagnostic()?;
+    let commit_message_path =
+        external::resolve_commit_message_path(cli_args.commit_message_path, &current_dir)?;
 
     let git_config = Git2::try_from(current_dir)?;
 


### PR DESCRIPTION
## Summary

[lefthook](https://github.com/evilmartians/lefthook) replaces git hooks with its own runner and does not forward git's positional arguments to the commands it invokes. This caused `mit-commit-msg` and `mit-prepare-commit-msg` to fail with `required arguments were not provided` when run under lefthook.

The commit message path argument is now optional in both hooks. When omitted, they discover the git repository and fall back to `<gitdir>/COMMIT_EDITMSG`, the canonical file git writes the draft commit message to.

This implements the user's **Solution 2** from the issue — all three git-mit hooks can now be configured in `lefthook.yml` without any argument forwarding:

```yaml
pre-commit:
  commands:
    git-mit:
      run: mit-pre-commit
prepare-commit-msg:
  commands:
    git-mit:
      run: mit-prepare-commit-msg
commit-msg:
  commands:
    git-mit:
      run: mit-commit-msg
```

## Changes

- New `resolve_commit_message_path` function in `mit-commit-message-lints` that returns the provided path or falls back to `<gitdir>/COMMIT_EDITMSG` via repo discovery
- `mit-commit-msg` and `mit-prepare-commit-msg`: commit path is now fully optional (was `required_unless_present="completion"`)
- Removed dead `CommitPathMissing` / `MissingCommitFilePath` error variants
- New specdown end-to-end test (`docs/lefthook.md`) that installs lefthook, configures all three hooks without argument forwarding, and verifies co-author trailers appear in the commit
- CI: added `npm install -g lefthook` to the specdown job

## Test Plan

- [x] 4 new unit tests for `resolve_commit_message_path` (provided path, fallback, subdirectory discovery, error outside repo)
- [x] Updated specdown tests for both hook binaries (no-argument fallback)
- [x] New specdown integration test with real lefthook (`docs/lefthook.md`)
- [x] Full suite: 233 specdown functions, all pass
- [x] `cargo +nightly clippy --all-targets` — zero warnings
- [x] `cargo +nightly fmt -- --check` — clean

Closes #1588