### PR TITLE
feat: add available authors hint to no-author and stale-author errors

### DIFF
--- a/docs/binaries/mit-pre-commit.md
+++ b/docs/binaries/mit-pre-commit.md
@@ -38,7 +38,8 @@ Error: mit_pre_commit::errors::no_author_error
 
   × No authors set
   help: Can you set who's currently coding? It's nice to get and give the
-        right credit. You can fix this by running `git mit` then the initials
-        of whoever is coding for example: `git mit bt` or `git mit bt se`
+        right credit. You can fix this by running `git mit` with the initials
+        of whoever is coding (e.g. `git mit bt`). To list available authors,
+        run `git mit-config mit available`
 
 ```

--- a/mit-pre-commit/src/errors.rs
+++ b/mit-pre-commit/src/errors.rs
@@ -28,7 +28,7 @@ impl Diagnostic for StaleAuthorError {
     }
 
     fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
-        Some(Box::new("Can you confirm who's currently coding? It's nice to get and give the right credit. You can fix this by running `git mit` then the initials of whoever is coding for example: `git mit bt` or `git mit bt se`"))
+        Some(Box::new("Can you confirm who's currently coding? It's nice to get and give the right credit. You can fix this by running `git mit` with the initials of whoever is coding (e.g. `git mit bt`). To list available authors, run `git mit-config mit available`"))
     }
 
     fn source_code(&self) -> Option<&dyn SourceCode> {
@@ -51,6 +51,6 @@ impl Diagnostic for StaleAuthorError {
 #[error("No authors set")]
 #[diagnostic(
 code(mit_pre_commit::errors::no_author_error),
-help("Can you set who's currently coding? It's nice to get and give the right credit. You can fix this by running `git mit` then the initials of whoever is coding for example: `git mit bt` or `git mit bt se`")
+help("Can you set who's currently coding? It's nice to get and give the right credit. You can fix this by running `git mit` with the initials of whoever is coding (e.g. `git mit bt`). To list available authors, run `git mit-config mit available`")
 )]
 pub struct NoAuthorError {}


### PR DESCRIPTION
When no author is set or the author has expired, the error message now includes instructions on how to list all available authors using `git mit-config mit available`.