### PR TITLE
fix: use shell wrapper instead of symlink on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ git init .
 git mit-install
 ```
 
-This works by creating a symlink in your repositories hooks directory.
+This works by installing the hooks in your repositories hooks directory
+(a symlink on Unix, a shell wrapper on Windows).
 You can do this automatically by adding them to your [init
 template](https://git-scm.com/docs/git-init#_template_directory). This
 is the template that git uses to create the `.git` directory when you

--- a/docs/troubleshooting/error-messages.md
+++ b/docs/troubleshooting/error-messages.md
@@ -25,12 +25,11 @@ which format failed:
 
 The hook installation failed because:
 
-- **ExistingHook**: A non-symlink hook already exists at that location
-- **ExistingSymlink**: A symlink exists but points to a different
-  location
+- **ExistingHook**: A hook already exists at that location (a regular file,
+  or a symlink/wrapper that is not git-mit's)
 - You don't have write permissions to the hooks directory
 
-Remove the existing hook or check where the existing symlink points.
+Remove the existing hook and run `git mit-install` again.
 
 ## "No authors set" (from pre-commit hook)
 

--- a/docs/troubleshooting/hooks.md
+++ b/docs/troubleshooting/hooks.md
@@ -11,12 +11,14 @@ isn't working:
     ls -la .git/hooks/ | grep mit
     ```
 
-    You should see symbolic links for:
+    You should see git-mit's hooks for:
 
-    - `commit-msg` → mit-commit-msg (or mit-commit-msg.exe on Windows)
-    - `pre-commit` → mit-pre-commit (or mit-pre-commit.exe on Windows)
-    - `prepare-commit-msg` → mit-prepare-commit-msg (or
-      mit-prepare-commit-msg.exe on Windows)
+    - `commit-msg`
+    - `pre-commit`
+    - `prepare-commit-msg`
+
+    On Unix these are symlinks to the mit binaries; on Windows they are small
+    `#!/bin/sh` wrappers that invoke them.
 
 2.  **For global installations, check the template directory**:
 

--- a/docs/troubleshooting/storage.md
+++ b/docs/troubleshooting/storage.md
@@ -142,11 +142,16 @@ overriding earlier ones if there are conflicts.
 
 ## Hook Installation Details
 
-The installation process creates symbolic links to the git-mit binaries:
+The installation process creates a reference to the git-mit binaries so the
+hooks stay in sync when the binaries are updated:
 
-- **Windows**: Creates file symbolic links with `.exe` extension
-- **Unix/Linux/macOS**: Creates standard symbolic links
-- **Existing hooks**: Installation will fail if hooks already exist
-  (unless they're already symlinks to git-mit)
-- **Symlink validation**: If a symlink exists but points to the correct
-  binary, installation succeeds silently
+- **Windows**: writes a small `#!/bin/sh` wrapper (named exactly `pre-commit`,
+  `commit-msg`, `prepare-commit-msg`) that `exec`s the absolute mit binary.
+  This needs no Administrator privilege and is run by Git for Windows' bundled
+  bash
+- **Unix/Linux/macOS**: creates a symbolic link to the binary
+- **Existing hooks**: installation will fail if a non-git-mit hook already
+  exists at that location
+- **Re-running**: if the hook is already correctly installed (a symlink
+  resolving to the binary on Unix, or a wrapper whose content matches on
+  Windows), installation succeeds silently

--- a/docs/troubleshooting/storage.md
+++ b/docs/troubleshooting/storage.md
@@ -61,7 +61,8 @@ troubleshooting:
     `git mit-install --scope=local`):
 
     - Location: `.git/hooks/` in current repository
-    - Creates symbolic links to the actual git-mit binaries
+    - Installs the git-mit hooks (a symlink on Unix, a shell wrapper on
+      Windows)
 
 2.  **Global installation** (`git mit-install --scope=global`):
 

--- a/git-mit-install/src/errors.rs
+++ b/git-mit-install/src/errors.rs
@@ -7,11 +7,4 @@ pub enum GitMitInstallError {
         help("{0} already exists, you need to remove this before continuing")
     )]
     ExistingHook(String),
-    #[error("failed to install hook")]
-    #[diagnostic(
-        code(git_mit_install::errors::git_mit_install_error::existing_symlink),
-
-        help("{0} already exists, you need to remove this before continuing, looks like it's a symlink to {1}")
-    )]
-    ExistingSymlink(String, String),
 }

--- a/git-mit-install/src/hook/install.rs
+++ b/git-mit-install/src/hook/install.rs
@@ -1,43 +1,85 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use miette::{IntoDiagnostic, Result};
 
 use crate::errors::GitMitInstallError;
+
+/// Convert OS path separators to forward slashes so a path is valid inside a
+/// `#!/bin/sh` wrapper on Windows. On Unix this is effectively a no-op.
+fn path_forward_slashes(path: &Path) -> String {
+    path.display().to_string().replace('\\', "/")
+}
+
+/// The exact content of the Windows hook wrapper: a POSIX shell script that
+/// execs the resolved mit binary, forwarding all arguments.
+fn wrapper_content(binary_path: &Path) -> String {
+    let target = path_forward_slashes(binary_path);
+    format!("#!/bin/sh\nexec \"{target}\" \"$@\"\n")
+}
+
+/// True iff the file at `install_path` contains exactly our wrapper for
+/// `binary_path`. Used for idempotent re-install on Windows.
+fn is_our_wrapper(install_path: &Path, binary_path: &Path) -> bool {
+    std::fs::read_to_string(install_path)
+        .is_ok_and(|content| content == wrapper_content(binary_path))
+}
+
 pub fn link(hook_path: &Path, hook_name: &str) -> Result<()> {
-    #[cfg(target_os = "windows")]
-    let suffix = ".exe";
-    #[cfg(not(target_os = "windows"))]
-    let suffix = "";
-    let binary_path = which::which(format!("mit-{hook_name}{suffix}")).into_diagnostic()?;
+    let binary_path = which::which(binary_name(hook_name)).into_diagnostic()?;
     let binary_path = binary_path.canonicalize().into_diagnostic()?;
-    let install_path = hook_path.join(format!("{hook_name}{suffix}"));
-    if let Ok(existing_hook_path) = install_path.canonicalize() {
-        if existing_hook_path == binary_path {
-            return Ok(());
-        }
+    let install_path = hook_path.join(install_name(hook_name));
+
+    if already_installed(&install_path, &binary_path) {
+        return Ok(());
     }
 
     if install_path.exists() {
-        if let Ok(dest) = install_path.canonicalize() {
-            return Err(GitMitInstallError::ExistingSymlink(
-                install_path.to_string_lossy().to_string(),
-                dest.to_string_lossy().to_string(),
-            )
-            .into());
-        }
-
         return Err(
             GitMitInstallError::ExistingHook(install_path.to_string_lossy().to_string()).into(),
         );
     }
 
-    symlink(binary_path, install_path)?;
+    #[cfg(target_os = "windows")]
+    write_wrapper(&binary_path, &install_path)?;
+    #[cfg(not(target_os = "windows"))]
+    symlink(&binary_path, &install_path)?;
 
     Ok(())
 }
 
+/// The mit binary to locate on `PATH`, e.g. `mit-pre-commit` (unix) or
+/// `mit-pre-commit.exe` (windows).
+fn binary_name(hook_name: &str) -> String {
+    #[cfg(target_os = "windows")]
+    let suffix = ".exe";
+    #[cfg(not(target_os = "windows"))]
+    let suffix = "";
+    format!("mit-{hook_name}{suffix}")
+}
+
+/// The filename Git looks for in the hooks directory. On every platform this is
+/// the bare hook name (`pre-commit`); Git's `find_hook` does not try extensions,
+/// so a `.exe` suffix here would be silently ignored on Windows.
+fn install_name(hook_name: &str) -> String {
+    hook_name.to_string()
+}
+
+/// True iff the hook at `install_path` is already correctly installed for
+/// `binary_path`. On unix a path resolving to the binary counts; on windows a
+/// wrapper whose content matches ours counts. Both branches compile on every
+/// platform so the windows logic is unit-testable on unix.
+fn already_installed(install_path: &Path, binary_path: &Path) -> bool {
+    if cfg!(target_os = "windows") {
+        is_our_wrapper(install_path, binary_path)
+    } else {
+        install_path
+            .canonicalize()
+            .is_ok_and(|resolved| resolved == binary_path)
+    }
+}
+
 #[cfg(not(target_os = "windows"))]
-fn symlink(binary_path: PathBuf, install_path: PathBuf) -> Result<()> {
+fn symlink(binary_path: &Path, install_path: &Path) -> Result<()> {
     std::os::unix::fs::symlink(binary_path, install_path).into_diagnostic()?;
 
     Ok(())
@@ -99,8 +141,145 @@ mod tests {
 }
 
 #[cfg(target_os = "windows")]
-fn symlink(binary_path: PathBuf, install_path: PathBuf) -> Result<()> {
-    std::os::windows::fs::symlink_file(binary_path, install_path).into_diagnostic()?;
+fn write_wrapper(binary_path: &Path, install_path: &Path) -> Result<()> {
+    std::fs::write(install_path, wrapper_content(binary_path)).into_diagnostic()
+}
 
-    Ok(())
+#[cfg(test)]
+mod pure_tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn path_forward_slashes_converts_backslashes() {
+        let p = path_forward_slashes(&PathBuf::from(r"C:\Users\git-mit\mit-pre-commit.exe"));
+        assert_eq!(
+            p, "C:/Users/git-mit/mit-pre-commit.exe",
+            "backslashes must become forward slashes for use in a shell script"
+        );
+    }
+
+    #[test]
+    fn path_forward_slashes_leaves_unix_paths_unchanged() {
+        let p = path_forward_slashes(&PathBuf::from("/usr/local/bin/mit-pre-commit"));
+        assert_eq!(
+            p, "/usr/local/bin/mit-pre-commit",
+            "unix paths already use forward slashes"
+        );
+    }
+
+    #[test]
+    fn wrapper_content_targets_canonical_path_with_shebang() {
+        let content = wrapper_content(&PathBuf::from(r"C:\Users\git-mit\mit-pre-commit.exe"));
+        assert_eq!(
+            content, "#!/bin/sh\nexec \"C:/Users/git-mit/mit-pre-commit.exe\" \"$@\"\n",
+            "wrapper must be a sh script that execs the absolute, slash-normalised binary"
+        );
+    }
+
+    #[test]
+    fn is_our_wrapper_is_true_for_our_wrapper_content() {
+        let temp = std::env::temp_dir().join(format!(
+            "git-mit-install-pure-test-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&temp).unwrap();
+
+        let binary = temp.join("mit-pre-commit");
+        std::fs::write(&binary, b"binary-bytes").unwrap();
+        let binary = binary.canonicalize().unwrap();
+
+        let hook = temp.join("pre-commit");
+        std::fs::write(&hook, wrapper_content(&binary)).unwrap();
+
+        assert!(
+            is_our_wrapper(&hook, &binary),
+            "a file containing our exact wrapper content must count as already installed"
+        );
+
+        let _ = std::fs::remove_dir_all(&temp);
+    }
+
+    #[test]
+    fn is_our_wrapper_is_false_for_foreign_file() {
+        let temp = std::env::temp_dir().join(format!(
+            "git-mit-install-pure-test-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&temp).unwrap();
+
+        let binary = temp.join("mit-pre-commit");
+        std::fs::write(&binary, b"binary-bytes").unwrap();
+        let binary = binary.canonicalize().unwrap();
+
+        let hook = temp.join("pre-commit");
+        std::fs::write(&hook, b"#!/bin/sh\necho someone elses hook\n").unwrap();
+
+        assert!(
+            !is_our_wrapper(&hook, &binary),
+            "a file with different content must not count as already installed"
+        );
+
+        let _ = std::fs::remove_dir_all(&temp);
+    }
+}
+
+#[cfg(all(test, target_os = "windows"))]
+mod windows_tests {
+    use super::*;
+
+    #[test]
+    fn link_writes_runnable_wrapper_and_is_idempotent() {
+        let temp = std::env::temp_dir().join(format!(
+            "git-mit-install-win-test-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let hook_dir = temp.join("hooks");
+        let bin_dir = temp.join("bin");
+        std::fs::create_dir_all(&hook_dir).unwrap();
+        std::fs::create_dir_all(&bin_dir).unwrap();
+
+        // Place a mit-pre-commit.exe on PATH so `which` can resolve it.
+        let binary = bin_dir.join("mit-pre-commit.exe");
+        std::fs::write(&binary, b"placeholder").unwrap();
+        let old_path = std::env::var("PATH").unwrap_or_default();
+        std::env::set_var("PATH", format!("{};{old_path}", bin_dir.display()));
+
+        // First install writes the wrapper at the bare hook name Git looks for.
+        link(&hook_dir, "pre-commit").unwrap();
+        let hook = hook_dir.join("pre-commit");
+        assert!(
+            hook.exists(),
+            "hook must be written at its bare name for Git to find it"
+        );
+        assert!(
+            !hook_dir.join("pre-commit.exe").exists(),
+            "must not create the .exe-named hook that Git ignores"
+        );
+
+        let content = std::fs::read_to_string(&hook).unwrap();
+        assert!(
+            content.starts_with("#!/bin/sh\n"),
+            "wrapper must be a sh script, got: {content:?}"
+        );
+
+        // Second install must be a no-op, not an error.
+        let again = link(&hook_dir, "pre-commit");
+        assert!(
+            again.is_ok(),
+            "re-install must be idempotent, got {again:?}"
+        );
+
+        std::env::set_var("PATH", old_path);
+        let _ = std::fs::remove_dir_all(&temp);
+    }
 }


### PR DESCRIPTION
## Summary

`git mit-install` failed on Windows for two compounding reasons:

1. **Privilege failure (the reported symptom):** the Windows code path
   called `std::os::windows::fs::symlink_file`, which throws OS error
   1314 ("A required privilege is not held") for any non-Administrator
   user without Developer Mode enabled — i.e. most installs.
2. **Wrong hook filename (silent failure even when #1 is bypassed):**
   the hook was installed as `pre-commit.exe`, but Git's `find_hook()`
   only ever looks for exactly `pre-commit` — so even admin/dev-mode
   users got hooks that Git silently ignored.

### Fix

On Windows, write a tiny `#!/bin/sh` wrapper (named exactly
`pre-commit`, `commit-msg`, `prepare-commit-msg`) that `exec`s the
resolved absolute mit binary. This needs no privilege and is run by Git
for Windows' bundled bash (same form as the shipped `.sample` hooks).
Idempotent by content comparison.

Unix/macOS symlinks are unchanged.

### Implementation notes

- The Windows-specific logic is extracted into pure, cross-platform
  helpers (`path_forward_slashes`, `wrapper_content`, `is_our_wrapper`)
  so it is unit-testable on Linux via the `pure_tests` module.
- `already_installed` uses `cfg!` so both branches compile everywhere.
- Removed the now-unused `ExistingSymlink` error variant (private type
  in a binary crate; the foreign-file case is covered by `ExistingHook`).
- A Windows-only integration test (`windows_tests`) is `#[cfg]`-gated
  and runs in CI's Windows leg.

## Test Plan

- [x] `cargo test -p git-mit-install` — 6 passed (5 new pure-helper
      tests + existing unix symlink test)
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo +nightly clippy -p git-mit-install` — clean (pedantic +
      nursery, zero warnings)
- [x] Full workspace `cargo test` — all pass
- [ ] CI Windows runner executes the gated integration test