### PR TITLE
fix: remove redundant shells from generate_completions_from_executable template

### DIFF
--- a/homebrew/formula.rb.j2
+++ b/homebrew/formula.rb.j2
@@ -25,11 +25,7 @@ class GitMit < Formula
       system "cargo", "install", *std_cargo_args(path: "./#{binary}/")
 
       # Completions
-      generate_completions_from_executable(bin/binary.to_s, "--completion", shells: [
-        :bash,
-        :fish,
-        :zsh,
-      ])
+      generate_completions_from_executable(bin/binary.to_s, "--completion")
 
       # Man pages
       output = Utils.safe_popen_read("help2man", bin/binary.to_s)


### PR DESCRIPTION
Homebrew's `FormulaAudit/RedundantGenerateCompletionsShells` audit now flags the explicit `shells: [:bash, :fish, :zsh]` argument to `generate_completions_from_executable` as redundant, because those are already the defaults.

This removes the `shells:` parameter from the `generate_completions_from_executable` call in `homebrew/formula.rb.j2` so that formulas generated from this template pass the audit cleanly.

## Changes
- `homebrew/formula.rb.j2`: simplified
  ```ruby
  generate_completions_from_executable(bin/binary.to_s, "--completion", shells: [
    :bash,
    :fish,
    :zsh,
  ])
  ```
  to
  ```ruby
  generate_completions_from_executable(bin/binary.to_s, "--completion")
  ```

The resulting completions behavior is unchanged, since bash, fish, and zsh are the default shells.