### PR TITLE
feat: allow disabling of author bit

### DIFF
--- a/docs/binaries/git-mit-config.md
+++ b/docs/binaries/git-mit-config.md
@@ -60,6 +60,8 @@ Commands:
   set-non-clean-behaviour  Set the current behavior when the repository is mid-rebase or merge
   rotation                 Get the current rotation setting for primary author across commits
   set-rotation             Set the rotation setting for primary author across commits
+  author-status            Get whether the author bit (Co-authored-by trailer) is enabled
+  set-author-status        Enable or disable the author bit (Co-authored-by trailer)
   generate                 Generate a file version of available authors
   available                List available authors
   example                  Print example mit toml file

--- a/git-mit-config/src/cli/app.rs
+++ b/git-mit-config/src/cli/app.rs
@@ -135,6 +135,24 @@ pub enum Mit {
         )]
         rotation: RotationOption,
     },
+    /// Get whether the author bit (Co-authored-by trailer) is enabled
+    AuthorStatus {
+        #[clap(long, value_enum, value_parser, default_value = "local")]
+        scope: Scope,
+    },
+    /// Enable or disable the author bit (Co-authored-by trailer)
+    SetAuthorStatus {
+        #[clap(long, value_enum, value_parser, default_value = "local")]
+        scope: Scope,
+        /// Whether to enable (true) or disable (false) the author bit
+        #[clap(
+            index = 1,
+            env = "GIT_MIT_SET_AUTHOR_STATUS",
+            default_value = "true",
+            num_args = 1
+        )]
+        enabled: bool,
+    },
     /// Generate a file version of available authors
     Generate {
         /// Path to a file where mit initials, emails and names can be found

--- a/git-mit-config/src/cmd/author_status.rs
+++ b/git-mit-config/src/cmd/author_status.rs
@@ -1,0 +1,18 @@
+use std::env::current_dir;
+
+use miette::{IntoDiagnostic, Result};
+use mit_commit_message_lints::{
+    mit::cmd::get_config_author_status::get_config_author_status, scope::Scope,
+};
+
+use crate::get_vcs;
+
+pub fn run(scope: Scope) -> Result<()> {
+    let current_dir = current_dir().into_diagnostic()?;
+    let vcs = get_vcs(scope == Scope::Local, &current_dir)?;
+
+    let result = get_config_author_status(&vcs)?;
+    mit_commit_message_lints::console::style::to_be_piped(&result.to_string());
+
+    Ok(())
+}

--- a/git-mit-config/src/cmd/author_status_set.rs
+++ b/git-mit-config/src/cmd/author_status_set.rs
@@ -1,7 +1,9 @@
 use std::env::current_dir;
 
 use miette::{IntoDiagnostic, Result};
-use mit_commit_message_lints::{mit::cmd::set_config_author_status::set_config_author_status, scope::Scope};
+use mit_commit_message_lints::{
+    mit::cmd::set_config_author_status::set_config_author_status, scope::Scope,
+};
 
 use crate::get_vcs;
 

--- a/git-mit-config/src/cmd/author_status_set.rs
+++ b/git-mit-config/src/cmd/author_status_set.rs
@@ -1,0 +1,15 @@
+use std::env::current_dir;
+
+use miette::{IntoDiagnostic, Result};
+use mit_commit_message_lints::{mit::cmd::set_config_author_status::set_config_author_status, scope::Scope};
+
+use crate::get_vcs;
+
+pub fn run(scope: Scope, enabled: bool) -> Result<()> {
+    let current_dir = current_dir().into_diagnostic()?;
+    let mut vcs = get_vcs(scope == Scope::Local, &current_dir)?;
+
+    set_config_author_status(&mut vcs, enabled)?;
+
+    Ok(())
+}

--- a/git-mit-config/src/cmd/mod.rs
+++ b/git-mit-config/src/cmd/mod.rs
@@ -1,6 +1,8 @@
 pub mod author_example;
 pub mod author_generate;
 pub mod author_set;
+pub mod author_status;
+pub mod author_status_set;
 pub mod lint_available;
 pub mod lint_disable;
 pub mod lint_enable;

--- a/git-mit-config/src/main.rs
+++ b/git-mit-config/src/main.rs
@@ -110,6 +110,12 @@ fn main() -> Result<()> {
         Some(Action::Mit {
             action: app::Mit::SetRotation { scope, rotation },
         }) => cmd::rotation_set::run(scope, rotation),
+        Some(Action::Mit {
+            action: app::Mit::AuthorStatus { scope },
+        }) => cmd::author_status::run(scope),
+        Some(Action::Mit {
+            action: app::Mit::SetAuthorStatus { scope, enabled },
+        }) => cmd::author_status_set::run(scope, enabled),
         Some(Action::RelatesTo {
             action: app::RelatesTo::Template { scope, template },
         }) => cmd::relates_to_template::run(scope, &template),

--- a/mit-commit-message-lints/src/mit/cmd/get_config_author_status.rs
+++ b/mit-commit-message-lints/src/mit/cmd/get_config_author_status.rs
@@ -1,0 +1,69 @@
+//! Get whether the author trailer (Co-authored-by) is enabled
+use miette::Result;
+
+use crate::external::Vcs;
+
+const CONFIG_KEY_AUTHOR_STATUS: &str = "mit.author.enabled";
+
+/// Get whether the author bit (Co-authored-by trailer) is enabled.
+///
+/// Defaults to `true` when not set, meaning authors are added to commits.
+/// When set to `false`, the prepare-commit-msg hook will not append
+/// Co-authored-by trailers.
+///
+/// # Errors
+///
+/// Returns an error if reading the git config fails.
+pub fn get_config_author_status(store: &dyn Vcs) -> Result<bool> {
+    Ok(store
+        .get_bool(CONFIG_KEY_AUTHOR_STATUS)?
+        .unwrap_or(true))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use crate::external::InMemory;
+
+    #[test]
+    fn get_config_author_status_defaults_to_true_when_not_set() {
+        let mut buffer = BTreeMap::new();
+        let vcs_config = InMemory::new(&mut buffer);
+
+        let result = super::get_config_author_status(&vcs_config);
+
+        assert!(
+            result.unwrap(),
+            "Expected author status to default to true when not set"
+        );
+    }
+
+    #[test]
+    fn get_config_author_status_returns_true_when_set_to_true() {
+        let mut buffer = BTreeMap::new();
+        buffer.insert("mit.author.enabled".into(), "true".into());
+        let vcs_config = InMemory::new(&mut buffer);
+
+        let result = super::get_config_author_status(&vcs_config);
+
+        assert!(
+            result.unwrap(),
+            "Expected author status to be true when set to 'true'"
+        );
+    }
+
+    #[test]
+    fn get_config_author_status_returns_false_when_set_to_false() {
+        let mut buffer = BTreeMap::new();
+        buffer.insert("mit.author.enabled".into(), "false".into());
+        let vcs_config = InMemory::new(&mut buffer);
+
+        let result = super::get_config_author_status(&vcs_config);
+
+        assert!(
+            !result.unwrap(),
+            "Expected author status to be false when set to 'false'"
+        );
+    }
+}

--- a/mit-commit-message-lints/src/mit/cmd/get_config_author_status.rs
+++ b/mit-commit-message-lints/src/mit/cmd/get_config_author_status.rs
@@ -15,9 +15,7 @@ const CONFIG_KEY_AUTHOR_STATUS: &str = "mit.author.enabled";
 ///
 /// Returns an error if reading the git config fails.
 pub fn get_config_author_status(store: &dyn Vcs) -> Result<bool> {
-    Ok(store
-        .get_bool(CONFIG_KEY_AUTHOR_STATUS)?
-        .unwrap_or(true))
+    Ok(store.get_bool(CONFIG_KEY_AUTHOR_STATUS)?.unwrap_or(true))
 }
 
 #[cfg(test)]

--- a/mit-commit-message-lints/src/mit/cmd/mod.rs
+++ b/mit-commit-message-lints/src/mit/cmd/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod set_commit_authors;
 pub(crate) mod set_config_authors;
 
 pub mod errors;
+pub mod get_config_author_status;
 pub mod get_config_non_clean_behaviour;
 
 /// Configuration for rotating primary author across commits
@@ -17,6 +18,7 @@ pub mod get_config_non_clean_behaviour;
 pub mod get_config_rotation;
 /// Rotate the primary author among configured authors
 pub mod rotate_authors;
+pub mod set_config_author_status;
 pub mod set_config_non_clean_behaviour;
 /// Configuration for rotating primary author across commits
 pub mod set_config_rotation;

--- a/mit-commit-message-lints/src/mit/cmd/set_config_author_status.rs
+++ b/mit-commit-message-lints/src/mit/cmd/set_config_author_status.rs
@@ -1,0 +1,73 @@
+//! Set whether the author trailer (Co-authored-by) is enabled
+use miette::Result;
+
+use crate::external::Vcs;
+
+const CONFIG_KEY_AUTHOR_STATUS: &str = "mit.author.enabled";
+
+/// Set whether the author bit (Co-authored-by trailer) is enabled.
+///
+/// When set to `false`, the prepare-commit-msg hook will not append
+/// Co-authored-by trailers to commit messages.
+///
+/// # Errors
+///
+/// Returns an error if writing to the git config fails.
+pub fn set_config_author_status(store: &mut dyn Vcs, enabled: bool) -> Result<()> {
+    store.set_str(CONFIG_KEY_AUTHOR_STATUS, &enabled.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use crate::external::InMemory;
+
+    #[test]
+    fn set_config_author_status_writes_true_and_reads_back() {
+        let mut buffer = BTreeMap::new();
+        {
+            let mut vcs_config = InMemory::new(&mut buffer);
+            super::set_config_author_status(&mut vcs_config, true).unwrap();
+        }
+
+        assert_eq!(
+            buffer.get("mit.author.enabled"),
+            Some(&"true".to_string()),
+            "Expected the author status config to be set to 'true'"
+        );
+    }
+
+    #[test]
+    fn set_config_author_status_writes_false_and_reads_back() {
+        let mut buffer = BTreeMap::new();
+        {
+            let mut vcs_config = InMemory::new(&mut buffer);
+            super::set_config_author_status(&mut vcs_config, false).unwrap();
+        }
+
+        assert_eq!(
+            buffer.get("mit.author.enabled"),
+            Some(&"false".to_string()),
+            "Expected the author status config to be set to 'false'"
+        );
+    }
+
+    #[test]
+    fn set_config_author_status_round_trips_through_get() {
+        let mut buffer = BTreeMap::new();
+        {
+            let mut vcs_config = InMemory::new(&mut buffer);
+            super::set_config_author_status(&mut vcs_config, false).unwrap();
+        }
+
+        let vcs_config = InMemory::new(&mut buffer);
+        let result = crate::mit::cmd::get_config_author_status::get_config_author_status(
+            &vcs_config,
+        );
+        assert!(
+            !result.unwrap(),
+            "Expected author status to be false after setting it to false"
+        );
+    }
+}

--- a/mit-commit-message-lints/src/mit/cmd/set_config_author_status.rs
+++ b/mit-commit-message-lints/src/mit/cmd/set_config_author_status.rs
@@ -62,9 +62,8 @@ mod tests {
         }
 
         let vcs_config = InMemory::new(&mut buffer);
-        let result = crate::mit::cmd::get_config_author_status::get_config_author_status(
-            &vcs_config,
-        );
+        let result =
+            crate::mit::cmd::get_config_author_status::get_config_author_status(&vcs_config);
         assert!(
             !result.unwrap(),
             "Expected author status to be false after setting it to false"

--- a/mit-commit-message-lints/src/mit/mod.rs
+++ b/mit-commit-message-lints/src/mit/mod.rs
@@ -3,13 +3,13 @@
 pub use cmd::{
     get_authors::{AuthorArgs, GenericArgs, get_authors},
     get_commit_coauthor_configuration::get_commit_coauthor_configuration,
-    get_config_rotation::get_config_rotation,
     get_config_author_status::get_config_author_status,
+    get_config_rotation::get_config_rotation,
     rotate_authors::rotate_authors,
     set_commit_authors::set_commit_authors,
+    set_config_author_status::set_config_author_status,
     set_config_authors::set_config_authors,
     set_config_rotation::set_config_rotation,
-    set_config_author_status::set_config_author_status,
 };
 pub use lib::{
     author::Author, author_state::AuthorState, authors::Authors, rotation_option::RotationOption,

--- a/mit-commit-message-lints/src/mit/mod.rs
+++ b/mit-commit-message-lints/src/mit/mod.rs
@@ -4,10 +4,12 @@ pub use cmd::{
     get_authors::{AuthorArgs, GenericArgs, get_authors},
     get_commit_coauthor_configuration::get_commit_coauthor_configuration,
     get_config_rotation::get_config_rotation,
+    get_config_author_status::get_config_author_status,
     rotate_authors::rotate_authors,
     set_commit_authors::set_commit_authors,
     set_config_authors::set_config_authors,
     set_config_rotation::set_config_rotation,
+    set_config_author_status::set_config_author_status,
 };
 pub use lib::{
     author::Author, author_state::AuthorState, authors::Authors, rotation_option::RotationOption,

--- a/mit-prepare-commit-msg/src/main.rs
+++ b/mit-prepare-commit-msg/src/main.rs
@@ -36,6 +36,7 @@ use mit_commit_message_lints::{
     mit::{
         Author, AuthorState,
         cmd::{
+            get_config_author_status::get_config_author_status,
             get_config_non_clean_behaviour::get_config_non_clean_behaviour,
             get_config_rotation::get_config_rotation, rotate_authors::rotate_authors,
         },
@@ -104,7 +105,9 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
-    if let AuthorState::Some(authors) = get_commit_coauthor_configuration(&git_config)? {
+    if get_config_author_status(&git_config)?
+        && let AuthorState::Some(authors) = get_commit_coauthor_configuration(&git_config)?
+    {
         append_coauthors_to_commit_message(commit_message_path.clone(), &authors)?;
 
         // Rotate primary author for the next commit if rotation is enabled


### PR DESCRIPTION
Closes #1592

## Summary

Adds a configuration option to disable the author bit (Co-authored-by trailer) in git-mit, making it optional like the other lint-y bits.

## Changes

- **New config key**: `mit.author.enabled` in git config (defaults to `true` for backward compatibility)
- **New CLI commands**:
  - `git-mit-config mit author-status` — get whether the author bit is enabled
  - `git-mit-config mit set-author-status <true|false>` — enable or disable the author bit
- **prepare-commit-msg hook**: checks `get_config_author_status` before appending Co-authored-by trailers; when disabled, no trailers are added

## Implementation

- `get_config_author_status` reads `mit.author.enabled`, defaulting to `true`
- `set_config_author_status` writes `mit.author.enabled` to git config
- The `mit-prepare-commit-msg` hook gates the coauthor appending logic on this config value using `let` chaining

## Test plan

- [x] `cargo build` — compiles cleanly
- [x] `cargo test --workspace` — all 116 tests pass (6 new tests for author status get/set)
- [x] `cargo clippy --workspace` — no warnings
- [x] `git-mit-config mit author-status --help` — correct help text
- [x] `git-mit-config mit set-author-status --help` — correct help text
- [x] Default behavior unchanged (author bit enabled by default)