### PR TITLE
fix(deps): upgrade crossbeam-epoch to 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary

Patches RUSTSEC-2026-0204 — an invalid pointer dereference in the `fmt::Pointer` impl for `Atomic` and `Shared` when the underlying pointer is invalid (e.g. `Atomic::null` / `Shared::null`).

- **Advisory**: RUSTSEC-2026-0204
- **Package**: crossbeam-epoch v0.9.18 → v0.9.20
- **Upstream fix**: https://github.com/crossbeam-rs/crossbeam/pull/1276

## Dependency chain

```
criterion = "=0.8.2" (dev-dependency)
  → rayon → rayon-core → crossbeam-deque → crossbeam-epoch v0.9.18
```

## Changes

Cargo.lock-only update — no source code changes needed.

```diff
-name = "crossbeam-epoch"
-version = "0.9.18"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+name = "crossbeam-epoch"
+version = "0.9.20"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
```

## Verification

- [x] `cargo update -p crossbeam-epoch --precise 0.9.20` applied cleanly
- [x] `cargo check` passes
- [ ] CI `rust-check / security-audit` passes

## Context

This vulnerability is currently blocking all open renovate PRs (#1655–#1678) which fail on the `rust-check / security-audit` job.