### PR TITLE
chore: add specdown.toml for standardised configuration

### DIFF
--- a/specdown.toml
+++ b/specdown.toml
@@ -1,0 +1,2 @@
+[run]
+add_path = ["target/release"]


### PR DESCRIPTION
## Summary

Add a `specdown.toml` at the repository root that encodes the `--add-path target/release` setting currently passed manually by the `bin/specdown` wrapper script.

This standardises the configuration so that `specdown run` auto-loads `target/release` from the config file without requiring the CLI flag.

```toml
[run]
add_path = ["target/release"]
```

The `bin/specdown` wrapper still works as before — its explicit `--add-path` flag overrides the config value per the [specdown config precedence rules](https://github.com/specdown/specdown/blob/master/docs/cli/config_file.md) (CLI > file), so this change is fully backward-compatible.

## Test Plan

- [x] `cargo build --release` succeeds
- [x] `just specdown` passes all specs (0 failures across all spec files)