### PR TITLE
fix(deps): update crossbeam-epoch to v0.9.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,9 +382,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## What does this do?

Bumps `crossbeam-epoch` from 0.9.18 to 0.9.20 in `Cargo.lock`.

## Why?

This clears [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204). The `security-audit` job has been failing on main since 2026-07-14 because of this advisory, which also blocks the automated `cog bump --auto` release job, so main has not shipped a release since v6.4.1.

`crossbeam-epoch` is a transitive dev-dependency (`criterion` -> `rayon` -> `rayon-core` -> `crossbeam-deque`), so no direct dependency pins change and the diff is lockfile-only.

## Checklist

- [x] `cargo audit` passes (only pre-existing, allowed warnings remain)
- [x] `cargo test` passes (110 tests, 0 failures)
- [x] Lockfile-only change, no source or manifest changes